### PR TITLE
Add optional $params to Tickets::getById

### DIFF
--- a/src/Resources/Tickets.php
+++ b/src/Resources/Tickets.php
@@ -64,15 +64,19 @@ class Tickets extends Resource
     }
 
     /**
-     * @param int $id
+     * @param int   $id
+     * @param array $params Optional parameters ['properties', 'propertiesWithHistory', 'includeDeletes']
      *
      * @return mixed
+     * @throws \SevenShores\Hubspot\Exceptions\BadRequest
      */
-    public function getById($id)
+    public function getById($id, array $params = [])
     {
         $endpoint = "https://api.hubapi.com/crm-objects/v1/objects/tickets/{$id}";
 
-        return $this->client->request('get', $endpoint);
+        $queryString = build_query_string($params);
+
+        return $this->client->request('get', $endpoint, [], $queryString);
     }
 
     /**


### PR DESCRIPTION
The Tickets API supports optional parameters when getting by ID, [documented here](https://developers.hubspot.com/docs/methods/tickets/get_ticket_by_id), which the Tickets resource doesn't support.

This PR adds in an optional $params parameter to the Tickets::getById so we can actually use the query string for this call.