### PR TITLE
Expose Factory::$client property through getter

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -61,6 +61,14 @@ class Factory
     }
 
     /**
+     * @return Client
+     */
+    public function getClient()
+    {
+        return $this->client;
+    }
+
+    /**
      * Return an instance of a Resource based on the method called.
      *
      * @param string $name


### PR DESCRIPTION
I've previously used the implicitly public `$client` property from the `Factory` class to create helpers for APIs this library currently doesn't support, like [CRM Pipelines](https://developers.hubspot.com/docs/methods/pipelines/pipelines_overview), the change made in #219 broke my helpers which were using the `$client` property, hence this PR to expose the property via a getter instead.