### PR TITLE
fix: remove API keys from error messages

### DIFF
--- a/src/Exceptions/BadRequest.php
+++ b/src/Exceptions/BadRequest.php
@@ -2,6 +2,6 @@
 
 namespace SevenShores\Hubspot\Exceptions;
 
-class BadRequest extends \Exception
+class BadRequest extends HubspotException
 {
 }

--- a/src/Exceptions/HubspotException.php
+++ b/src/Exceptions/HubspotException.php
@@ -9,7 +9,7 @@ use GuzzleHttp\Psr7\Response;
 class HubspotException extends Exception
 {
     /** @var Response|null */
-    private $response;
+    protected $response;
 
     /**
      * @return Response|null
@@ -32,7 +32,7 @@ class HubspotException extends Exception
         return $e;
     }
 
-    private static function sanitizeResponseMessage(string $message): string
+    protected static function sanitizeResponseMessage(string $message): string
     {
         return preg_replace('/(hapikey|access_token)=[a-z0-9-]+/i', '$1=***', $message);
     }

--- a/src/Exceptions/HubspotException.php
+++ b/src/Exceptions/HubspotException.php
@@ -22,7 +22,7 @@ class HubspotException extends Exception
     public static function create(RequestException $guzzleException): self
     {
         $e = new static(
-            self::sanitizeResponseMessage($guzzleException->getMessage()),
+            static::sanitizeResponseMessage($guzzleException->getMessage()),
             $guzzleException->getCode(),
             $guzzleException
         );

--- a/src/Exceptions/HubspotException.php
+++ b/src/Exceptions/HubspotException.php
@@ -2,6 +2,38 @@
 
 namespace SevenShores\Hubspot\Exceptions;
 
-class HubspotException extends \Exception
+use Exception;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Psr7\Response;
+
+class HubspotException extends Exception
 {
+    /** @var Response|null */
+    private $response;
+
+    /**
+     * @return Response|null
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
+
+    public static function create(RequestException $guzzleException): self
+    {
+        $e = new static(
+            self::sanitizeResponseMessage($guzzleException->getMessage()),
+            $guzzleException->getCode(),
+            $guzzleException
+        );
+
+        $e->response = $guzzleException->getResponse();
+
+        return $e;
+    }
+
+    private static function sanitizeResponseMessage(string $message): string
+    {
+        return preg_replace('/(hapikey|access_token)=[a-z0-9-]+/i', '$1=***', $message);
+    }
 }

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -3,6 +3,8 @@
 namespace SevenShores\Hubspot\Http;
 
 use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\ServerException;
 use Psr\Http\Message\ResponseInterface;
 use SevenShores\Hubspot\Exceptions\BadRequest;
 use SevenShores\Hubspot\Exceptions\HubspotException;
@@ -106,10 +108,10 @@ class Client
             }
 
             return new Response($this->client->request($method, $url, $options));
-        } catch (\GuzzleHttp\Exception\ServerException $e) {
-            throw new HubspotException(\GuzzleHttp\Psr7\str($e->getResponse()), $e->getCode(), $e);
-        } catch (\GuzzleHttp\Exception\ClientException $e) {
-            throw new BadRequest($e->getMessage(), $e->getCode(), $e);
+        } catch (ServerException $e) {
+            throw HubspotException::create($e);
+        } catch (ClientException $e) {
+            throw BadRequest::create($e);
         }
     }
 

--- a/tests/unit/Exception/HubspotExceptionTest.php
+++ b/tests/unit/Exception/HubspotExceptionTest.php
@@ -17,7 +17,8 @@ class HubspotExceptionTest extends TestCase
 {
     const EXAMPLE_TOKEN = '8907e60c-600d-4af8-a987-191c104a215c';
 
-    public function testCreateExceptionFromGuzzleRequestException()
+    /** @test */
+    public function createExceptionFromGuzzleRequestException()
     {
         $e = new RequestException('Request Failed', new Request('GET', 'https://api.hubspot.com/x'));
 
@@ -27,12 +28,13 @@ class HubspotExceptionTest extends TestCase
         $this->assertNull($hubspotException->getResponse());
     }
 
-    public function testCreateExceptionFromGuzzleClientException()
+    /** @test */
+    public function createExceptionFromGuzzleClientException()
     {
         $e = ClientException::create(
             new Request(
                 'GET',
-                sprintf('https://api.hubapi.com/deals/v1/deal/12345?access_token=%s', self::EXAMPLE_TOKEN)
+                sprintf('https://api.hubapi.com/deals/v1/deal/12345?access_token=%s', static::EXAMPLE_TOKEN)
             ),
             new Response(
                 400,
@@ -44,19 +46,20 @@ class HubspotExceptionTest extends TestCase
         $hubspotException = BadRequest::create($e);
 
         $this->assertInstanceOf(BadRequest::class, $hubspotException);
-        $this->assertNotContains(self::EXAMPLE_TOKEN, $hubspotException->getMessage());
+        $this->assertNotContains(static::EXAMPLE_TOKEN, $hubspotException->getMessage());
         $this->assertSame($e->getResponse(), $hubspotException->getResponse());
         $this->assertSame('Client error: `GET https://api.hubapi.com/deals/v1/deal/12345?access_token=***` resulted in a `400 Bad Request` response:
 {"status":"error","message":"xyz"}
 ', $hubspotException->getMessage());
     }
 
-    public function testCreateExceptionFromGuzzleServerException()
+    /** @test */
+    public function createExceptionFromGuzzleServerException()
     {
         $e = ServerException::create(
             new Request(
                 'GET',
-                sprintf('https://api.hubapi.com/deals/v1/deal/12345?hapikey=%s', self::EXAMPLE_TOKEN)
+                sprintf('https://api.hubapi.com/deals/v1/deal/12345?hapikey=%s', static::EXAMPLE_TOKEN)
             ),
             new Response(
                 502,
@@ -69,7 +72,7 @@ class HubspotExceptionTest extends TestCase
         $hubspotException = HubspotException::create($e);
 
         $this->assertInstanceOf(HubspotException::class, $hubspotException);
-        $this->assertNotContains(self::EXAMPLE_TOKEN, $hubspotException->getMessage());
+        $this->assertNotContains(static::EXAMPLE_TOKEN, $hubspotException->getMessage());
         $this->assertSame($e->getResponse(), $hubspotException->getResponse());
         $this->assertSame('Server error: `GET https://api.hubapi.com/deals/v1/deal/12345?hapikey=***` resulted in a `502 Bad Gateway` response:
 <!DOCTYPE html>

--- a/tests/unit/Exception/HubspotExceptionTest.php
+++ b/tests/unit/Exception/HubspotExceptionTest.php
@@ -1,0 +1,79 @@
+<?php
+declare(strict_types=1);
+
+namespace SevenShores\Hubspot\Tests\unit\Exception;
+
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\ServerException;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use SevenShores\Hubspot\Exceptions\BadRequest;
+use SevenShores\Hubspot\Exceptions\HubspotException;
+use function GuzzleHttp\Psr7\stream_for;
+
+class HubspotExceptionTest extends TestCase
+{
+    const EXAMPLE_TOKEN = '8907e60c-600d-4af8-a987-191c104a215c';
+
+    public function testCreateExceptionFromGuzzleRequestException()
+    {
+        $e = new RequestException('Request Failed', new Request('GET', 'https://api.hubspot.com/x'));
+
+        $hubspotException = HubspotException::create($e);
+
+        $this->assertInstanceOf(HubspotException::class, $hubspotException);
+        $this->assertNull($hubspotException->getResponse());
+    }
+
+    public function testCreateExceptionFromGuzzleClientException()
+    {
+        $e = ClientException::create(
+            new Request(
+                'GET',
+                sprintf('https://api.hubapi.com/deals/v1/deal/12345?access_token=%s', self::EXAMPLE_TOKEN)
+            ),
+            new Response(
+                400,
+                [],
+                stream_for('{"status":"error","message":"xyz"}')
+            )
+        );
+
+        $hubspotException = BadRequest::create($e);
+
+        $this->assertInstanceOf(BadRequest::class, $hubspotException);
+        $this->assertNotContains(self::EXAMPLE_TOKEN, $hubspotException->getMessage());
+        $this->assertSame($e->getResponse(), $hubspotException->getResponse());
+        $this->assertSame('Client error: `GET https://api.hubapi.com/deals/v1/deal/12345?access_token=***` resulted in a `400 Bad Request` response:
+{"status":"error","message":"xyz"}
+', $hubspotException->getMessage());
+    }
+
+    public function testCreateExceptionFromGuzzleServerException()
+    {
+        $e = ServerException::create(
+            new Request(
+                'GET',
+                sprintf('https://api.hubapi.com/deals/v1/deal/12345?hapikey=%s', self::EXAMPLE_TOKEN)
+            ),
+            new Response(
+                502,
+                [],
+                stream_for('<!DOCTYPE html>
+<!--[if lt IE 7]> <html class="no-js ie6 oldie" lang="en-US"> <![endif]-->')
+            )
+        );
+
+        $hubspotException = HubspotException::create($e);
+
+        $this->assertInstanceOf(HubspotException::class, $hubspotException);
+        $this->assertNotContains(self::EXAMPLE_TOKEN, $hubspotException->getMessage());
+        $this->assertSame($e->getResponse(), $hubspotException->getResponse());
+        $this->assertSame('Server error: `GET https://api.hubapi.com/deals/v1/deal/12345?hapikey=***` resulted in a `502 Bad Gateway` response:
+<!DOCTYPE html>
+<!--[if lt IE 7]> <html class="no-js ie6 oldie" lang="en-US"> <![endif]-->
+', $hubspotException->getMessage());
+    }
+}


### PR DESCRIPTION
Closes #88 

I've also added tests to cover the new logic :)