### PR TITLE
fix: ci improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,19 @@ language: php
 php:
   - 7.0
   - 7.1
+  - 7.2
+  - 7.3
+  - 7.4
 
 sudo: false
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 before_script:
   - travis_retry composer self-update
-  - travis_retry composer install --no-interaction --prefer-source
+  - travis_retry composer install --no-interaction --prefer-dist
 
 script:
   - vendor/bin/phpspec run --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,18 @@
 language: php
-
-php:
-  - 7.0
-  - 7.1
-  - 7.2
-  - 7.3
-  - 7.4
-
 sudo: false
+
+jobs:
+  include:
+    - php: 7.0
+      env: PHPUNIT_SUITE=All
+    - php: 7.1
+      env: PHPUNIT_SUITE=Unit
+    - php: 7.2
+      env: PHPUNIT_SUITE=Unit
+    - php: 7.3
+      env: PHPUNIT_SUITE=Unit
+    - php: 7.4
+      env: PHPUNIT_SUITE=All
 
 cache:
   directories:
@@ -19,4 +24,4 @@ before_script:
 
 script:
   - vendor/bin/phpspec run --verbose
-  - vendor/bin/phpunit --verbose
+  - vendor/bin/phpunit --verbose --testsuite $PHPUNIT_SUITE

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,8 +9,14 @@
          stopOnFailure="false"
          bootstrap="./vendor/autoload.php">
     <testsuites>
-        <testsuite name="Package Test Suite">
-            <directory>./tests/</directory>
+        <testsuite name="All">
+            <directory>./tests</directory>
+        </testsuite>
+        <testsuite name="Unit">
+            <directory>./tests/unit</directory>
+        </testsuite>
+        <testsuite name="Integration">
+            <directory>./tests/Integration</directory>
         </testsuite>
     </testsuites>
     <filter>


### PR DESCRIPTION
Noticed that travis was only running on PHP versions that are already.
https://www.php.net/supported-versions.php

As such, I've added all of the supported versions as well as configuring the cache to speed up the builds.

I also swapped the install command to use `dist` instead of source. IMO in CI it should match how people will be using the package (composer will instal from dist by default)