### PR TITLE
Add params to updateAutoSaveBuffer

### DIFF
--- a/src/Resources/Pages.php
+++ b/src/Resources/Pages.php
@@ -84,7 +84,8 @@ class Pages extends Resource
     /**
      * Updates the auto-save buffer.
      *
-     * @param in $page_id The page ID
+     * @param int $page_id The page ID
+     * @param array $params  the auto-save buffer fields to update
      *
      * @return \SevenShores\Hubspot\Http\Response
      */

--- a/src/Resources/Pages.php
+++ b/src/Resources/Pages.php
@@ -88,11 +88,13 @@ class Pages extends Resource
      *
      * @return \SevenShores\Hubspot\Http\Response
      */
-    public function updateAutoSaveBuffer($page_id)
+    public function updateAutoSaveBuffer($page_id, $params)
     {
         $endpoint = "https://api.hubapi.com/content/api/v2/pages/{$page_id}/buffer";
+        
+        $options['json'] = $params;
 
-        return $this->client->request('put', $endpoint);
+        return $this->client->request('put', $endpoint, $options);
     }
 
     /**


### PR DESCRIPTION
The updateAutoSaveBuffer function of the pages ressources is not sending the params when calling the endpoint. So no data is sent to be save to the page buffer.

https://developers.hubspot.com/docs/methods/pages/put_pages_page_id_buffer