### PR TITLE
[PHP-CS-FIXER] add native_function_invocation rule on function with compiler optimized

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -11,5 +11,9 @@ return PhpCsFixer\Config::create()
     ->setRules([
         '@PSR2' => true,
         '@PhpCsFixer' => true,
+        'native_function_invocation' => [
+            'include' => ['@compiler_optimized'],
+            'scope' => 'namespaced',
+        ],
     ])
 ;

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -64,7 +64,7 @@ class Factory
      */
     public function __construct(array $config = [], Client $client = null, array $clientOptions = [], $wrapResponse = true)
     {
-        if (is_null($client)) {
+        if (\is_null($client)) {
             $client = new Client($config, null, $clientOptions, $wrapResponse);
         }
         $this->client = $client;

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -70,7 +70,7 @@ class Client
             throw new InvalidArgument('Cannot sign requests with both OAuth1 and OAuth2');
         }
 
-        if (is_null($client)) {
+        if (\is_null($client)) {
             $client = new GuzzleClient();
         }
         $this->client = $client;

--- a/src/Resources/Engagements.php
+++ b/src/Resources/Engagements.php
@@ -56,7 +56,7 @@ class Engagements extends Resource
     {
         $availableMethods = ['put', 'patch'];
 
-        if (!in_array($method, $availableMethods)) {
+        if (!\in_array($method, $availableMethods)) {
             throw new BadRequest('Method name '.$method.' is invalid', 400);
         }
         $endpoint = "https://api.hubapi.com/engagements/v1/engagements/{$id}";

--- a/src/Resources/Files.php
+++ b/src/Resources/Files.php
@@ -45,7 +45,7 @@ class Files extends Resource
      */
     public function getResource($file)
     {
-        if (is_resource($file)) {
+        if (\is_resource($file)) {
             return $file;
         }
 
@@ -304,7 +304,7 @@ class Files extends Resource
 
     protected function getOptionValue($key, $option, array $params)
     {
-        if (isset($params[$option]) && array_key_exists($key, $params[$option])) {
+        if (isset($params[$option]) && \array_key_exists($key, $params[$option])) {
             return $params[$option][$key];
         }
 

--- a/src/Resources/Forms.php
+++ b/src/Resources/Forms.php
@@ -161,7 +161,7 @@ class Forms extends Resource
         $query_string = null;
         $parsed = explode('?', $url);
 
-        if (2 == count($parsed)) {
+        if (2 == \count($parsed)) {
             $endpoint = $parsed[0];
             $query_string = $parsed[1];
         }

--- a/src/Resources/HubDB.php
+++ b/src/Resources/HubDB.php
@@ -51,7 +51,7 @@ class HubDB extends Resource
             $endpoint,
             [],
             build_query_string($params),
-            boolval($draft)
+            \boolval($draft)
         );
     }
 
@@ -183,7 +183,7 @@ class HubDB extends Resource
             $endpoint,
             [],
             build_query_string($params),
-            boolval($draft)
+            \boolval($draft)
         );
     }
 

--- a/src/RetryMiddlewareFactory.php
+++ b/src/RetryMiddlewareFactory.php
@@ -91,7 +91,7 @@ class RetryMiddlewareFactory
                 return false;
             }
 
-            if (($response instanceof Response) && in_array($response->getStatusCode(), $codes)) {
+            if (($response instanceof Response) && \in_array($response->getStatusCode(), $codes)) {
                 return true;
             }
 

--- a/tests/Integration/Abstraction/CrmPipelinesTestCase.php
+++ b/tests/Integration/Abstraction/CrmPipelinesTestCase.php
@@ -81,7 +81,7 @@ class CrmPipelinesTestCase extends EntityTestCase
 
     protected function getData(string $label = null)
     {
-        if (is_null($label)) {
+        if (\is_null($label)) {
             $label = 'Demo '.$this->type.' Pipeline';
         }
 

--- a/tests/Integration/Abstraction/PropertiesTestCase.php
+++ b/tests/Integration/Abstraction/PropertiesTestCase.php
@@ -15,7 +15,7 @@ abstract class PropertiesTestCase extends EntityTestCase
         $response = $this->resource->all();
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertGreaterThanOrEqual(1, count($response->getData()));
+        $this->assertGreaterThanOrEqual(1, \count($response->getData()));
     }
 
     /** @test */

--- a/tests/Integration/Abstraction/PropertyGroupsTestCase.php
+++ b/tests/Integration/Abstraction/PropertyGroupsTestCase.php
@@ -20,7 +20,7 @@ abstract class PropertyGroupsTestCase extends EntityTestCase
         $response = $this->resource->{$this->allGroupsMethod}();
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertGreaterThanOrEqual(1, count($response->getData()));
+        $this->assertGreaterThanOrEqual(1, \count($response->getData()));
         $this->assertObjectNotHasAttribute('properties', $response->getData()[0]);
     }
 
@@ -30,7 +30,7 @@ abstract class PropertyGroupsTestCase extends EntityTestCase
         $response = $this->resource->{$this->allGroupsMethod}(true);
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertGreaterThanOrEqual(1, count($response->getData()));
+        $this->assertGreaterThanOrEqual(1, \count($response->getData()));
         $this->assertObjectHasAttribute('properties', $response->getData()[0]);
     }
 

--- a/tests/Integration/Resources/BlogAuthorsTest.php
+++ b/tests/Integration/Resources/BlogAuthorsTest.php
@@ -30,7 +30,7 @@ class BlogAuthorsTest extends EntityTestCase
         ]);
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertLessThanOrEqual(2, count($response->objects));
+        $this->assertLessThanOrEqual(2, \count($response->objects));
         $this->assertGreaterThanOrEqual(3, $response->offset);
     }
 
@@ -58,7 +58,7 @@ class BlogAuthorsTest extends EntityTestCase
         ]);
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertLessThanOrEqual(5, count($response->objects));
+        $this->assertLessThanOrEqual(5, \count($response->objects));
     }
 
     /** @test */

--- a/tests/Integration/Resources/BlogPostsTest.php
+++ b/tests/Integration/Resources/BlogPostsTest.php
@@ -38,7 +38,7 @@ class BlogPostsTest extends BlogPostTestCase
         ]);
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertLessThanOrEqual(2, count($response->objects));
+        $this->assertLessThanOrEqual(2, \count($response->objects));
         $this->assertGreaterThanOrEqual(3, $response->offset);
     }
 
@@ -51,7 +51,7 @@ class BlogPostsTest extends BlogPostTestCase
         ]);
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertLessThanOrEqual(2, count($response['objects']));
+        $this->assertLessThanOrEqual(2, \count($response['objects']));
         $this->assertGreaterThanOrEqual(3, $response['offset']);
     }
 

--- a/tests/Integration/Resources/BlogTopicsTest.php
+++ b/tests/Integration/Resources/BlogTopicsTest.php
@@ -38,7 +38,7 @@ class BlogTopicsTest extends EntityTestCase
         ]);
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertLessThanOrEqual(2, count($response->objects));
+        $this->assertLessThanOrEqual(2, \count($response->objects));
         $this->assertGreaterThanOrEqual(3, $response->offset);
     }
 
@@ -66,7 +66,7 @@ class BlogTopicsTest extends EntityTestCase
         ]);
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertLessThanOrEqual(5, count($response->objects));
+        $this->assertLessThanOrEqual(5, \count($response->objects));
     }
 
     /** @test */

--- a/tests/Integration/Resources/CalendarEventsTest.php
+++ b/tests/Integration/Resources/CalendarEventsTest.php
@@ -100,7 +100,7 @@ class CalendarEventsTest extends EntityTestCase
         $response = $this->resource->all($startDate, $endDate);
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertGreaterThanOrEqual(1, count($response->getData()));
+        $this->assertGreaterThanOrEqual(1, \count($response->getData()));
     }
 
     /** @test */
@@ -113,7 +113,7 @@ class CalendarEventsTest extends EntityTestCase
         $response = $this->resource->allTasks($startDate, $endDate);
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertGreaterThanOrEqual(1, count($response->toArray()));
+        $this->assertGreaterThanOrEqual(1, \count($response->toArray()));
     }
 
     protected function createEntity()

--- a/tests/Integration/Resources/CompaniesTest.php
+++ b/tests/Integration/Resources/CompaniesTest.php
@@ -102,7 +102,7 @@ class CompaniesTest extends EntityTestCase
         $response = $this->resource->all();
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertGreaterThan(0, count($response->data->companies));
+        $this->assertGreaterThan(0, \count($response->data->companies));
     }
 
     /** @test */

--- a/tests/Integration/Resources/ContactsTest.php
+++ b/tests/Integration/Resources/ContactsTest.php
@@ -27,7 +27,7 @@ class ContactsTest extends EntityTestCase
         $response = $this->resource->all();
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertGreaterThanOrEqual(1, count($response->contacts));
+        $this->assertGreaterThanOrEqual(1, \count($response->contacts));
     }
 
     /** @test */
@@ -38,7 +38,7 @@ class ContactsTest extends EntityTestCase
         ]);
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertGreaterThanOrEqual(1, count($response->contacts));
+        $this->assertGreaterThanOrEqual(1, \count($response->contacts));
     }
 
     /** @test */
@@ -49,7 +49,7 @@ class ContactsTest extends EntityTestCase
         ]);
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertGreaterThanOrEqual(1, count($response->contacts));
+        $this->assertGreaterThanOrEqual(1, \count($response->contacts));
     }
 
     /** @test */

--- a/tests/Integration/Resources/DealPipelinesTest.php
+++ b/tests/Integration/Resources/DealPipelinesTest.php
@@ -44,7 +44,7 @@ class DealPipelinesTest extends EntityTestCase
         $response = $this->resource->getAllPipelines();
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertGreaterThanOrEqual(1, count($response->getData()));
+        $this->assertGreaterThanOrEqual(1, \count($response->getData()));
     }
 
     /**

--- a/tests/Integration/Resources/DealsTest.php
+++ b/tests/Integration/Resources/DealsTest.php
@@ -100,7 +100,7 @@ class DealsTest extends EntityTestCase
         ]);
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals(1, count($response->deals));
+        $this->assertEquals(1, \count($response->deals));
     }
 
     /**

--- a/tests/Integration/Resources/EcommerceBridgeTest.php
+++ b/tests/Integration/Resources/EcommerceBridgeTest.php
@@ -67,7 +67,7 @@ class EcommerceBridgeTest extends DefaultTestCase
         $response = $this->resource->allStores();
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertGreaterThanOrEqual(1, count($response->getData()->results));
+        $this->assertGreaterThanOrEqual(1, \count($response->getData()->results));
     }
 
     /** @test */
@@ -180,7 +180,7 @@ class EcommerceBridgeTest extends DefaultTestCase
 
     protected function getTimestamp()
     {
-        if (is_null($this->timestamp)) {
+        if (\is_null($this->timestamp)) {
             $this->timestamp = time();
         }
 

--- a/tests/Integration/Resources/EmailEventsTest.php
+++ b/tests/Integration/Resources/EmailEventsTest.php
@@ -33,7 +33,7 @@ class EmailEventsTest extends \PHPUnit_Framework_TestCase
     {
         $list = $this->resource->all(['limit' => 2]);
 
-        if (count($list->events) > 0) {
+        if (\count($list->events) > 0) {
             $response = $this->resource->getById(
                 $list->events[0]->id,
                 $list->events[0]->created
@@ -64,7 +64,7 @@ class EmailEventsTest extends \PHPUnit_Framework_TestCase
     {
         $list = $this->resource->getCampaignIds(['limit' => 2]);
 
-        if (count($list->campaigns) > 0) {
+        if (\count($list->campaigns) > 0) {
             $response = $this->resource->getCampaignById(
                 $list->campaigns[0]->id,
                 $list->campaigns[0]->appId

--- a/tests/Integration/Resources/FormsTest.php
+++ b/tests/Integration/Resources/FormsTest.php
@@ -22,7 +22,7 @@ class FormsTest extends EntityTestCase
         $response = $this->resource->all();
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertGreaterThanOrEqual(1, count($response->getData()));
+        $this->assertGreaterThanOrEqual(1, \count($response->getData()));
     }
 
     /** @test */

--- a/tests/Integration/Resources/HubDBTest.php
+++ b/tests/Integration/Resources/HubDBTest.php
@@ -18,7 +18,7 @@ class HubDBTest extends HubDBRowTestCase
         $response = $this->resource->tables();
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertGreaterThanOrEqual(1, count($response->objects));
+        $this->assertGreaterThanOrEqual(1, \count($response->objects));
     }
 
     /**

--- a/tests/Integration/Resources/KeywordsTest.php
+++ b/tests/Integration/Resources/KeywordsTest.php
@@ -29,7 +29,7 @@ class KeywordsTest extends \PHPUnit_Framework_TestCase
         sleep(1);
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertGreaterThanOrEqual(1, count($response->getData()));
+        $this->assertGreaterThanOrEqual(1, \count($response->getData()));
     }
 
     /** @test */

--- a/tests/Integration/Resources/LineItemsTest.php
+++ b/tests/Integration/Resources/LineItemsTest.php
@@ -57,7 +57,7 @@ class LineItemsTest extends EntityTestCase
         $response = $this->resource->all();
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertGreaterThanOrEqual(1, count($response->objects));
+        $this->assertGreaterThanOrEqual(1, \count($response->objects));
     }
 
     /** @test */

--- a/tests/Integration/Resources/ProductsTest.php
+++ b/tests/Integration/Resources/ProductsTest.php
@@ -29,7 +29,7 @@ class ProductsTest extends EntityTestCase
         $response = $this->resource->all();
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertGreaterThanOrEqual(1, count($response->objects));
+        $this->assertGreaterThanOrEqual(1, \count($response->objects));
     }
 
     /** @test */

--- a/tests/Integration/Resources/TimelineEventTypeProprtyTest.php
+++ b/tests/Integration/Resources/TimelineEventTypeProprtyTest.php
@@ -18,7 +18,7 @@ class TimelineEventTypePropertyTest extends TimelineWithProprtyTestCase
         $response = $this->resource->getEventTypeProperties($this->appId, $this->entity->id);
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertGreaterThanOrEqual(1, count($response->toArray()));
+        $this->assertGreaterThanOrEqual(1, \count($response->toArray()));
     }
 
     /**

--- a/tests/Integration/Resources/TimelineEventTypeTest.php
+++ b/tests/Integration/Resources/TimelineEventTypeTest.php
@@ -18,7 +18,7 @@ class TimelineEventTypeTest extends TimelineTestCase
         $response = $this->resource->getEventTypes($this->appId);
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertGreaterThanOrEqual(1, count($response->toArray()));
+        $this->assertGreaterThanOrEqual(1, \count($response->toArray()));
     }
 
     /**


### PR DESCRIPTION
Hello

I have add a rule in PHP-CS-Fixer for use functions with compiler optimized when it's possible.

It applies in all of this function [here](https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/master/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php#L354)


Say me what's you think ? 