### PR TITLE
[Helpers] add check on bool type when build query string

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -17,11 +17,19 @@ if (!function_exists('build_query_string')) {
 
         $query = '';
         foreach ($params as $key => $value) {
+            if (empty($value)) {
+                continue;
+            }
+
             if (is_array($value)) {
                 $query .= build_batch_query_string($key, $value, $encoding);
-            } elseif (!empty($value)) {
-                $query .= '&'.url_encode($key, $encoding).'='.url_encode($value, $encoding);
+
+                continue;
             }
+
+            $parameter = url_encode($key, $encoding);
+            $propertyValue = is_bool($value) ? 'true' : url_encode($value, $encoding);
+            $query .= "&{$parameter}={$propertyValue}";
         }
 
         return $query ?: '';

--- a/tests/unit/Support/QueryBuilderTest.php
+++ b/tests/unit/Support/QueryBuilderTest.php
@@ -8,17 +8,16 @@ namespace SevenShores\Hubspot\Tests\Unit\Support;
  */
 class QueryBuilderTest extends \PHPUnit_Framework_TestCase
 {
-    /** @test */
-    public function build()
+    /**
+     * @test
+     * @dataProvider buildDataProvider
+     *
+     * @param array $params
+     * @param string $result
+     */
+    public function build(array $params, string $result)
     {
-        $query = [
-            'firstname' => 'joe',
-            'lastname' => 'blo',
-        ];
-
-        $queryString = build_query_string($query);
-
-        $this->assertEquals('&firstname=joe&lastname=blo', $queryString);
+        $this->assertEquals($result, build_query_string($params));
     }
 
     /** @test */
@@ -107,5 +106,15 @@ class QueryBuilderTest extends \PHPUnit_Framework_TestCase
         $queryString = url_encode($string, false);
 
         $this->assertEquals($string, $queryString);
+    }
+
+    public function buildDataProvider()
+    {
+        yield 'string' => [['firstname' => 'joe', 'lastname' => 'blo'], '&firstname=joe&lastname=blo'];
+        yield 'int' => [['firstname' => 'joe', 'active' => 1], '&firstname=joe&active=1'];
+        yield 'bool true' => [['firstname' => 'joe', 'active' => true], '&firstname=joe&active=true'];
+        yield 'bool false' => [['firstname' => 'joe', 'active' => false], '&firstname=joe'];
+        yield 'empty array' => [['firstname' => 'joe', 'property' => []], '&firstname=joe'];
+        yield 'array' => [['firstname' => 'joe', 'property' => ['foo']], '&firstname=joe&property=foo'];
     }
 }


### PR DESCRIPTION
Hi, I saw in several place in Hubspot doc when you use `optional query string options` the value needed is 'true'.

you can see it [here](https://developers.hubspot.com/docs/methods/files/post_files) for parameters `overwrite` and `hidden`.

When I read it for me 'true' is a boolean, but when you use a param with `true` the query_string_options convert it into integer.
So instead of have `hidden=true` I have `hidden=1` and this doesn't work with Hubspot API.

I make an update in `query_string_options` in case of a boolean is passed in the query, the return should be  `true` instead of 1.

What do you think ?

Thanks