### PR TITLE
Add support for removing list contacts by email address

### DIFF
--- a/src/Resources/ContactLists.php
+++ b/src/Resources/ContactLists.php
@@ -222,7 +222,7 @@ class ContactLists extends Resource
      *
      * @return \SevenShores\Hubspot\Http\Response
      */
-    public function removeContact($listId, array $contactIds)
+    public function removeContact($listId, array $contactIds, array $emails = [])
     {
         $endpoint = "https://api.hubapi.com/contacts/v1/lists/{$listId}/remove";
 
@@ -232,6 +232,7 @@ class ContactLists extends Resource
             [
                 'json' => [
                     'vids' => $contactIds,
+                    'emails' => $emails,
                 ],
             ]
         );


### PR DESCRIPTION
The endpoint to remove contacts from a list will also support an array of emails being passed through. This changes the removeContact signature to match the addContact signature by adding an optional 3rd parameter to the removeContact method so that users may be removed from a list by email address.

Closes #317.