### PR TITLE
Add support for adding/deleting secondary email addresses API

### DIFF
--- a/src/Resources/Contacts.php
+++ b/src/Resources/Contacts.php
@@ -443,6 +443,25 @@ class Contacts extends Resource
     }
 
     /**
+     * @param int $id
+     * @param string $emailToAdd
+     * @return \SevenShores\Hubspot\Http\Response
+     *
+     * @see https://legacydocs.hubspot.com/docs/methods/contacts/add-a-secondary-email-address
+     *
+     * @return \SevenShores\Hubspot\Http\Response
+     */
+    public function addSecondaryEmail($id, $emailToAdd)
+    {
+        $endpoint = "https://api.hubapi.com/contacts/v1/secondary-email/{$id}/email/{$emailToAdd}";
+
+        return $this->client->request(
+            'put',
+            $endpoint
+        );
+    }
+
+    /**
      * Get Lifecycle Stage metrics for Contacts.
      *
      * @see https://developers.hubspot.com/docs/methods/contacts/get-lifecycle-stage-metrics-for-contacts

--- a/src/Resources/Contacts.php
+++ b/src/Resources/Contacts.php
@@ -424,6 +424,25 @@ class Contacts extends Resource
     }
 
     /**
+     * @param int $id
+     * @param string $emailToDelete
+     * @return \SevenShores\Hubspot\Http\Response
+     *
+     * @see https://legacydocs.hubspot.com/docs/methods/contacts/delete-a-secondary-email-address
+     *
+     * @return \SevenShores\Hubspot\Http\Response
+     */
+    public function deleteSecondaryEmail($id, $emailToDelete)
+    {
+        $endpoint = "https://api.hubapi.com/contacts/v1/secondary-email/{$id}/email/{$emailToDelete}";
+
+        return $this->client->request(
+            'delete',
+            $endpoint
+        );
+    }
+
+    /**
      * Get Lifecycle Stage metrics for Contacts.
      *
      * @see https://developers.hubspot.com/docs/methods/contacts/get-lifecycle-stage-metrics-for-contacts

--- a/tests/Integration/Resources/ContactsTest.php
+++ b/tests/Integration/Resources/ContactsTest.php
@@ -231,6 +231,29 @@ class ContactsTest extends EntityTestCase
     }
 
     /** @test */
+    public function addSecondaryEmail()
+    {
+        $secondaryEmail = 'rw_test'.uniqid().'@hubspot.com';
+
+        $response = $this->resource->addSecondaryEmail($this->entity->vid, $secondaryEmail);
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    /** @test */
+    public function deleteSecondaryEmail()
+    {
+        $secondaryEmail = 'rw_test'.uniqid().'@hubspot.com';
+
+        $response = $this->resource->addSecondaryEmail($this->entity->vid, $secondaryEmail);
+        $this->assertEquals(200, $response->getStatusCode());
+
+        sleep(1);
+
+        $response = $this->resource->deleteSecondaryEmail($this->entity->vid, $secondaryEmail);
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    /** @test */
     public function getLifecycleStageMetrics()
     {
         $response = $this->resource->getLifecycleStageMetrics();


### PR DESCRIPTION
Hubspot API supports deleting & adding secondary email addresses, but the library doesnt have those methods. 

https://legacydocs.hubspot.com/docs/methods/contacts/add-a-secondary-email-address
https://legacydocs.hubspot.com/docs/methods/contacts/delete-a-secondary-email-address

This PR simply adds those methods with their corresponding tests.