### PR TITLE
Support to send options with Company::getById()

### DIFF
--- a/src/Resources/Companies.php
+++ b/src/Resources/Companies.php
@@ -176,16 +176,22 @@ class Companies extends Resource
      * Returns a company with id $id.
      *
      * @param int $id
+     * @param array $params    Array of optional parameters ['includeMergeAudits', 'includePropertyVersions']
      *
      * @see https://developers.hubspot.com/docs/methods/companies/get_company
      *
      * @return \SevenShores\Hubspot\Http\Response
      */
-    public function getById($id)
+    public function getById($id, array $params = [])
     {
         $endpoint = "https://api.hubapi.com/companies/v2/companies/{$id}";
 
-        return $this->client->request('get', $endpoint);
+        return $this->client->request(
+            'get',
+            $endpoint,
+            [],
+            build_query_string($params)
+        );
     }
 
     /**

--- a/tests/Integration/Resources/CompaniesTest.php
+++ b/tests/Integration/Resources/CompaniesTest.php
@@ -152,6 +152,23 @@ class CompaniesTest extends EntityTestCase
     }
 
     /** @test */
+    public function getByIdWithVersions()
+    {
+        // Force a change to the description
+        $newDescription = 'Better descriptions are not easy to create.';
+        $properties = [
+            'name' => 'description',
+            'value' => $newDescription,
+        ];
+        $response = $this->resource->update($this->entity->companyId, $properties);
+
+        // Get multiple versions for property
+        $params = ['includePropertyVersions' => true];
+        $response = $this->resource->getById($this->entity->companyId, $params);
+        $this->assertCount(2, $response->getData()->properties->description->versions);
+    }
+
+    /** @test */
     public function getAssociatedContacts()
     {
         list($contactId) = $this->createAssociatedContact($this->entity->companyId);


### PR DESCRIPTION
Add support to Companies::getById() to pass options to the API.

## Details
Valid optional options that can be included are 'includeMergeAudits' and 'includePropertyVersions'.

Additional array argument added to method getById($id, array $params = [])