### PR TITLE
Remove unneeded defaults for files api

### DIFF
--- a/src/Resources/Files.php
+++ b/src/Resources/Files.php
@@ -277,11 +277,7 @@ class Files extends Resource
     protected function getDefaultOptions(): array
     {
         return [
-            'access' => 'PUBLIC_INDEXABLE',
-            'ttl' => 'P3M',
-            'overwrite' => false,
-            'duplicateValidationStrategy' => 'NONE',
-            'duplicateValidationScope' => 'ENTIRE_PORTAL',
+            'access' => 'PUBLIC_INDEXABLE'
         ];
     }
 }


### PR DESCRIPTION
This does 2 things: 

1. Removes `ttl` as a default. This is a destructive upload option meaning files will be deleted at the end of the ttl and are not recoverable. This is causing a lot of user pain as it's hard to track down where these options are being set. This should never be defaulted. 
2. Removes other default options that are already set in the api `overwrite`, `duplicateValidationStrategy` and `duplicateValidationScope`. These again are optional and not required for the api to function. 
3. leaves `access` as it is required and has the correct default. 