### PR TITLE
fix php8.1 deprecated message

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -62,7 +62,7 @@ class Response implements ResponseInterface, ArrayAccess
      *
      * @return bool
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->data->{$offset});
     }
@@ -74,7 +74,7 @@ class Response implements ResponseInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         $data = $this->toArray();
 
@@ -87,7 +87,7 @@ class Response implements ResponseInterface, ArrayAccess
      * @param mixed $offset
      * @param mixed $value
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->data->{$offset} = $value;
     }
@@ -97,7 +97,7 @@ class Response implements ResponseInterface, ArrayAccess
      *
      * @param mixed $offset
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->data->{$offset});
     }


### PR DESCRIPTION
We got the following message in our project when upgrading to `php8.1`, this PR will fix these deprecation warnings

```
PHP Deprecated:  Return type of SevenShores\Hubspot\Http\Response::offsetExists($offset) 
should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the 
#[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in 
/srv/backend/vendor/hubspot/hubspot-php/src/Http/Response.php on line 65
```

```
PHP Deprecated:  Return type of SevenShores\Hubspot\Http\Response::offsetGet($offset)
 should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the
 #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in
 /srv/backend/vendor/hubspot/hubspot-php/src/Http/Response.php on line 77
```

```
PHP Deprecated:  Return type of SevenShores\Hubspot\Http\Response::offsetSet($offset, $value)
 should either be compatible with ArrayAccess::offsetSet(mixed $offset, mixed $value): void, or the
 #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in 
/srv/backend/vendor/hubspot/hubspot-php/src/Http/Response.php on line 90
```

```
PHP Deprecated:  Return type of SevenShores\Hubspot\Http\Response::offsetUnset($offset) 
should either be compatible with ArrayAccess::offsetUnset(mixed $offset): void, or the 
#[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in 
/srv/backend/vendor/hubspot/hubspot-php/src/Http/Response.php on line 100
```

We have version `v4.0.1` installed