### PR TITLE
Refactor: Updated naming from resources to endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $hubspot = new SevenShores\Hubspot\Factory([
 ]);
 
 // Then you can call a resource 
-// When referencing resources, use camelCase
+// When referencing endpoints, use camelCase
 
 $hubspot->contactlists
 ```

--- a/src/Endpoints/Endpoint.php
+++ b/src/Endpoints/Endpoint.php
@@ -10,7 +10,7 @@ abstract class Endpoint
     protected $client;
 
     /**
-     * Makin' a good old resource.
+     * Makin' a good old endpoint.
      *
      * @param \SevenShores\Hubspot\Http\Client $client
      */

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -12,9 +12,9 @@ class Utils
 {
     public function __call(string $name, $arguments = null)
     {
-        $resource = 'SevenShores\\Hubspot\\Utils\\'.ucfirst($name);
+        $endpoint = 'SevenShores\\Hubspot\\Utils\\'.ucfirst($name);
 
-        return new $resource();
+        return new $endpoint();
     }
 
     public static function getFactory()

--- a/tests/Integration/Abstraction/BlogPostTestCase.php
+++ b/tests/Integration/Abstraction/BlogPostTestCase.php
@@ -25,11 +25,11 @@ abstract class BlogPostTestCase extends EntityTestCase
         parent::setUp();
     }
 
-    protected function createPost(BlogPosts $resource)
+    protected function createPost(BlogPosts $endpoint)
     {
         $date = new DateTime();
 
-        return $resource->create([
+        return $endpoint->create([
             'name' => 'My Super Awesome Post '.uniqid(),
             'content_group_id' => $this->blogId,
             'publish_date' => $date->getTimestamp(),

--- a/tests/Integration/Abstraction/ContactListsTestCase.php
+++ b/tests/Integration/Abstraction/ContactListsTestCase.php
@@ -10,12 +10,12 @@ abstract class ContactListsTestCase extends EntityTestCase
     /**
      * @var ContactLists
      */
-    protected $resource;
+    protected $endpoint;
 
     /**
      * @var ContactLists::class
      */
-    protected $resourceClass = ContactLists::class;
+    protected $endpointClass = ContactLists::class;
 
     /**
      * @var bool
@@ -33,7 +33,7 @@ abstract class ContactListsTestCase extends EntityTestCase
 
     protected function createEntity()
     {
-        return $this->resource->create(
+        return $this->endpoint->create(
             [
                 'name' => 'Test '.uniqid(),
                 'dynamic' => $this->dynamic,
@@ -54,6 +54,6 @@ abstract class ContactListsTestCase extends EntityTestCase
 
     protected function deleteEntity()
     {
-        return $this->resource->delete($this->entity->listId);
+        return $this->endpoint->delete($this->entity->listId);
     }
 }

--- a/tests/Integration/Abstraction/CrmPipelinesTestCase.php
+++ b/tests/Integration/Abstraction/CrmPipelinesTestCase.php
@@ -18,17 +18,17 @@ class CrmPipelinesTestCase extends EntityTestCase
     /**
      * @var SevenShores\Hubspot\Endpoints\CrmPipelines
      */
-    protected $resource;
+    protected $endpoint;
 
     /**
      * @var SevenShores\Hubspot\Endpoints\CrmPipelines::class
      */
-    protected $resourceClass = CrmPipelines::class;
+    protected $endpointClass = CrmPipelines::class;
 
     public function setUp(): void
     {
-        if (empty($this->resource)) {
-            $this->resource = new $this->resourceClass($this->getClient(), $this->type);
+        if (empty($this->endpoint)) {
+            $this->endpoint = new $this->endpointClass($this->getClient(), $this->type);
         }
         sleep(1);
 
@@ -38,7 +38,7 @@ class CrmPipelinesTestCase extends EntityTestCase
     /** @test */
     public function getAllPipelinesTest()
     {
-        $response = $this->resource->all();
+        $response = $this->endpoint->all();
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -46,7 +46,7 @@ class CrmPipelinesTestCase extends EntityTestCase
     /** @test */
     public function getAllPipelinesIncludingDeleted()
     {
-        $response = $this->resource->all(['includeInactive' => 'INCLUDE_DELETED']);
+        $response = $this->endpoint->all(['includeInactive' => 'INCLUDE_DELETED']);
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -60,7 +60,7 @@ class CrmPipelinesTestCase extends EntityTestCase
     /** @test */
     public function updatePipeline()
     {
-        $response = $this->resource->update(
+        $response = $this->endpoint->update(
             $this->entity->pipelineId,
             $this->getData('Updated '.$this->type.' Pipeline')
         );
@@ -80,12 +80,12 @@ class CrmPipelinesTestCase extends EntityTestCase
 
     protected function createEntity()
     {
-        return $this->resource->create($this->getData());
+        return $this->endpoint->create($this->getData());
     }
 
     protected function deleteEntity()
     {
-        return $this->resource->delete($this->entity->pipelineId);
+        return $this->endpoint->delete($this->entity->pipelineId);
     }
 
     protected function getData(string $label = null)

--- a/tests/Integration/Abstraction/DefaultTestCase.php
+++ b/tests/Integration/Abstraction/DefaultTestCase.php
@@ -14,12 +14,12 @@ class DefaultTestCase extends TestCase
     /**
      * @var null|SevenShores\Hubspot\Endpoints\Endpoint
      */
-    protected $resource;
+    protected $endpoint;
 
     /**
      * @var null|SevenShores\Hubspot\Endpoints\Endpoint::class
      */
-    protected $resourceClass;
+    protected $endpointClass;
 
     /**
      * @var string
@@ -30,8 +30,8 @@ class DefaultTestCase extends TestCase
     {
         parent::setUp();
 
-        if (empty($this->resource)) {
-            $this->resource = new $this->resourceClass($this->getClient());
+        if (empty($this->endpoint)) {
+            $this->endpoint = new $this->endpointClass($this->getClient());
         }
         sleep(1);
     }

--- a/tests/Integration/Abstraction/HubDBRowTestCase.php
+++ b/tests/Integration/Abstraction/HubDBRowTestCase.php
@@ -10,12 +10,12 @@ abstract class HubDBRowTestCase extends EntityTestCase
     /**
      * @var null|Timeline
      */
-    protected $resource;
+    protected $endpoint;
 
     /**
      * @var null|Timeline::class
      */
-    protected $resourceClass = HubDB::class;
+    protected $endpointClass = HubDB::class;
 
     /**
      * @var string
@@ -34,7 +34,7 @@ abstract class HubDBRowTestCase extends EntityTestCase
 
     protected function createEntity()
     {
-        return $this->resource->createTable('Test Table'.uniqid(), [
+        return $this->endpoint->createTable('Test Table'.uniqid(), [
             [
                 'name' => 'Name',
                 'type' => 'TEXT',
@@ -48,6 +48,6 @@ abstract class HubDBRowTestCase extends EntityTestCase
 
     protected function deleteEntity()
     {
-        return $this->resource->deleteTable($this->entity->id);
+        return $this->endpoint->deleteTable($this->entity->id);
     }
 }

--- a/tests/Integration/Abstraction/PropertiesTestCase.php
+++ b/tests/Integration/Abstraction/PropertiesTestCase.php
@@ -12,7 +12,7 @@ abstract class PropertiesTestCase extends EntityTestCase
     /** @test */
     public function all()
     {
-        $response = $this->resource->all();
+        $response = $this->endpoint->all();
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertGreaterThanOrEqual(1, count($response->getData()));
@@ -21,7 +21,7 @@ abstract class PropertiesTestCase extends EntityTestCase
     /** @test */
     public function get()
     {
-        $response = $this->resource->get($this->entity->name);
+        $response = $this->endpoint->get($this->entity->name);
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals($this->entity->label, $response->label);
@@ -39,7 +39,7 @@ abstract class PropertiesTestCase extends EntityTestCase
     {
         $property = $this->getDataForUpdate();
 
-        $response = $this->resource->update($this->entity->name, $property);
+        $response = $this->endpoint->update($this->entity->name, $property);
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals($property['label'], $response->label);
@@ -62,7 +62,7 @@ abstract class PropertiesTestCase extends EntityTestCase
      */
     protected function createEntity()
     {
-        return $this->resource->create($this->getData());
+        return $this->endpoint->create($this->getData());
     }
 
     /**
@@ -72,7 +72,7 @@ abstract class PropertiesTestCase extends EntityTestCase
      */
     protected function deleteEntity()
     {
-        return $this->resource->delete($this->entity->name);
+        return $this->endpoint->delete($this->entity->name);
     }
 
     protected function getData()

--- a/tests/Integration/Abstraction/PropertyGroupsTestCase.php
+++ b/tests/Integration/Abstraction/PropertyGroupsTestCase.php
@@ -12,7 +12,7 @@ abstract class PropertyGroupsTestCase extends EntityTestCase
     /** @test */
     public function all()
     {
-        $response = $this->resource->getAllGroups();
+        $response = $this->endpoint->getAllGroups();
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertGreaterThanOrEqual(1, count($response->getData()));
@@ -22,7 +22,7 @@ abstract class PropertyGroupsTestCase extends EntityTestCase
     /** @test */
     public function allWithProperties()
     {
-        $response = $this->resource->getAllGroups(true);
+        $response = $this->endpoint->getAllGroups(true);
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertGreaterThanOrEqual(1, count($response->getData()));
@@ -35,7 +35,7 @@ abstract class PropertyGroupsTestCase extends EntityTestCase
         if (!$this->getGroup) {
             return true;
         }
-        $response = $this->resource->getGroup($this->entity->name);
+        $response = $this->endpoint->getGroup($this->entity->name);
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -55,7 +55,7 @@ abstract class PropertyGroupsTestCase extends EntityTestCase
             'displayOrder' => 7,
         ];
 
-        $response = $this->resource->updateGroup($this->entity->name, $group);
+        $response = $this->endpoint->updateGroup($this->entity->name, $group);
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals('An Updated Property Group', $response->displayName);
@@ -64,7 +64,7 @@ abstract class PropertyGroupsTestCase extends EntityTestCase
     /** @test */
     public function delete()
     {
-        $response = $this->resource->deleteGroup($this->entity->name);
+        $response = $this->endpoint->deleteGroup($this->entity->name);
 
         $this->assertEquals(204, $response->getStatusCode());
 
@@ -78,7 +78,7 @@ abstract class PropertyGroupsTestCase extends EntityTestCase
      */
     protected function deleteEntity()
     {
-        return $this->resource->deleteGroup($this->entity->name);
+        return $this->endpoint->deleteGroup($this->entity->name);
     }
 
     /**
@@ -94,6 +94,6 @@ abstract class PropertyGroupsTestCase extends EntityTestCase
             'displayOrder' => 7,
         ];
 
-        return $this->resource->createGroup($data);
+        return $this->endpoint->createGroup($data);
     }
 }

--- a/tests/Integration/Abstraction/TimelineTestCase.php
+++ b/tests/Integration/Abstraction/TimelineTestCase.php
@@ -10,12 +10,12 @@ abstract class TimelineTestCase extends EntityTestCase
     /**
      * @var null|Timeline
      */
-    protected $resource;
+    protected $endpoint;
 
     /**
      * @var null|Timeline::class
      */
-    protected $resourceClass = Timeline::class;
+    protected $endpointClass = Timeline::class;
 
     /**
      * @var string
@@ -40,7 +40,7 @@ abstract class TimelineTestCase extends EntityTestCase
 
     public function deleteEntity()
     {
-        return $this->resource->deleteEventType(
+        return $this->endpoint->deleteEventType(
             $this->appId,
             $this->entity->id
         );
@@ -48,7 +48,7 @@ abstract class TimelineTestCase extends EntityTestCase
 
     protected function createEntity()
     {
-        return $this->resource->createEventType(
+        return $this->endpoint->createEventType(
             $this->appId,
             'Test Event Name',
             'Test Event header template',

--- a/tests/Integration/Abstraction/TimelineWithProprtyTestCase.php
+++ b/tests/Integration/Abstraction/TimelineWithProprtyTestCase.php
@@ -26,7 +26,7 @@ abstract class TimelineWithProprtyTestCase extends TimelineTestCase
 
     public function deleteProperty()
     {
-        return $this->resource->deleteEventTypeProperty(
+        return $this->endpoint->deleteEventTypeProperty(
             $this->appId,
             $this->entity->id,
             $this->property->id
@@ -35,7 +35,7 @@ abstract class TimelineWithProprtyTestCase extends TimelineTestCase
 
     protected function createProperty()
     {
-        return $this->resource->createEventTypeProperty(
+        return $this->endpoint->createEventTypeProperty(
             $this->appId,
             $this->entity->id,
             'test_property',

--- a/tests/Integration/Endpoints/AnalyticsTest.php
+++ b/tests/Integration/Endpoints/AnalyticsTest.php
@@ -14,17 +14,17 @@ class AnalyticsTest extends DefaultTestCase
     /**
      * @var Analytics
      */
-    protected $resource;
+    protected $endpoint;
 
     /**
      * @var Analytics:class
      */
-    protected $resourceClass = Analytics::class;
+    protected $endpointClass = Analytics::class;
 
     /** @test */
     public function getByCategory()
     {
-        $response = $this->resource->getByCategory('totals', 'total', '20180101', '20180301');
+        $response = $this->endpoint->getByCategory('totals', 'total', '20180101', '20180301');
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -32,7 +32,7 @@ class AnalyticsTest extends DefaultTestCase
     /** @test */
     public function getByType()
     {
-        $response = $this->resource->getByType('forms', 'total', '20180101', '20180301');
+        $response = $this->endpoint->getByType('forms', 'total', '20180101', '20180301');
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -40,7 +40,7 @@ class AnalyticsTest extends DefaultTestCase
     /** @test */
     public function getHosted()
     {
-        $response = $this->resource->getHosted('standard-pages', 'total', '20180101', '20180301');
+        $response = $this->endpoint->getHosted('standard-pages', 'total', '20180101', '20180301');
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -48,7 +48,7 @@ class AnalyticsTest extends DefaultTestCase
     /** @test */
     public function checkForExistence()
     {
-        $response = $this->resource->checkForExistence('event-completions');
+        $response = $this->endpoint->checkForExistence('event-completions');
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -56,7 +56,7 @@ class AnalyticsTest extends DefaultTestCase
     /** @test */
     public function getEvents()
     {
-        $response = $this->resource->getEvents();
+        $response = $this->endpoint->getEvents();
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -64,7 +64,7 @@ class AnalyticsTest extends DefaultTestCase
     /** @test */
     public function getViews()
     {
-        $response = $this->resource->getViews();
+        $response = $this->endpoint->getViews();
 
         $this->assertEquals(200, $response->getStatusCode());
     }

--- a/tests/Integration/Endpoints/BlogAuthorsTest.php
+++ b/tests/Integration/Endpoints/BlogAuthorsTest.php
@@ -11,12 +11,12 @@ use SevenShores\Hubspot\Tests\Integration\Abstraction\EntityTestCase;
  */
 class BlogAuthorsTest extends EntityTestCase
 {
-    protected $resourceClass = BlogAuthors::class;
+    protected $endpointClass = BlogAuthors::class;
 
     /** @test */
     public function allWithNoParams()
     {
-        $response = $this->resource->all();
+        $response = $this->endpoint->all();
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -24,7 +24,7 @@ class BlogAuthorsTest extends EntityTestCase
     /** @test */
     public function allWithParams()
     {
-        $response = $this->resource->all([
+        $response = $this->endpoint->all([
             'limit' => 2,
             'offset' => 3,
         ]);
@@ -37,7 +37,7 @@ class BlogAuthorsTest extends EntityTestCase
     /** @test */
     public function searchWithoutQueryAndParams()
     {
-        $response = $this->resource->search();
+        $response = $this->endpoint->search();
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -45,7 +45,7 @@ class BlogAuthorsTest extends EntityTestCase
     /** @test */
     public function searchWithQueryAndWithoutParams()
     {
-        $response = $this->resource->search('john-smith');
+        $response = $this->endpoint->search('john-smith');
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -53,7 +53,7 @@ class BlogAuthorsTest extends EntityTestCase
     /** @test */
     public function searchWithQueryAndParams()
     {
-        $response = $this->resource->search('john-smith', [
+        $response = $this->endpoint->search('john-smith', [
             'limit' => 5,
         ]);
 
@@ -64,7 +64,7 @@ class BlogAuthorsTest extends EntityTestCase
     /** @test */
     public function getById()
     {
-        $response = $this->resource->getById($this->entity->id);
+        $response = $this->endpoint->getById($this->entity->id);
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -78,7 +78,7 @@ class BlogAuthorsTest extends EntityTestCase
     /** @test */
     public function update()
     {
-        $response = $this->resource->update($this->entity->id, [
+        $response = $this->endpoint->update($this->entity->id, [
             'bio' => 'Lorem ipsum dolor sit amet.',
             'website' => 'http://example.com',
         ]);
@@ -89,7 +89,7 @@ class BlogAuthorsTest extends EntityTestCase
     /** @test */
     public function delete()
     {
-        $response = $this->resource->delete($this->entity->id);
+        $response = $this->endpoint->delete($this->entity->id);
 
         $this->assertEquals(204, $response->getStatusCode());
 
@@ -98,7 +98,7 @@ class BlogAuthorsTest extends EntityTestCase
 
     protected function createEntity()
     {
-        return $this->resource->create([
+        return $this->endpoint->create([
             'fullName' => 'John Smith '.uniqid(),
             'email' => 'john.smith'.uniqid().'@example.com',
             'username' => 'john-smith',
@@ -107,6 +107,6 @@ class BlogAuthorsTest extends EntityTestCase
 
     protected function deleteEntity()
     {
-        $this->resource->delete($this->entity->id);
+        $this->endpoint->delete($this->entity->id);
     }
 }

--- a/tests/Integration/Endpoints/BlogCommentsTest.php
+++ b/tests/Integration/Endpoints/BlogCommentsTest.php
@@ -16,17 +16,17 @@ class BlogCommentsTest extends BlogPostTestCase
     /**
      * @var BlogComments
      */
-    protected $resource;
+    protected $endpoint;
 
     /**
      * @var BlogComments:class
      */
-    protected $resourceClass = BlogComments::class;
+    protected $endpointClass = BlogComments::class;
 
     /**
      * @var BlogPosts
      */
-    protected $blogPostsResource;
+    protected $blogPostsEndpoint;
 
     /**
      * @var null\SevenShores\Hubspot\Http\Response
@@ -35,7 +35,7 @@ class BlogCommentsTest extends BlogPostTestCase
 
     public function setUp(): void
     {
-        $this->blogPostsResource = new BlogPosts(new Client(['key' => getenv($this->key)]));
+        $this->blogPostsEndpoint = new BlogPosts(new Client(['key' => getenv($this->key)]));
 
         parent::setUp();
     }
@@ -51,7 +51,7 @@ class BlogCommentsTest extends BlogPostTestCase
     /** @test */
     public function all()
     {
-        $response = $this->resource->all();
+        $response = $this->endpoint->all();
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -59,7 +59,7 @@ class BlogCommentsTest extends BlogPostTestCase
     /** @test */
     public function getById()
     {
-        $response = $this->resource->getById($this->entity->id);
+        $response = $this->endpoint->getById($this->entity->id);
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -85,18 +85,18 @@ class BlogCommentsTest extends BlogPostTestCase
     {
         $this->deleteEntity();
 
-        $response = $this->resource->restore($this->entity->id);
+        $response = $this->endpoint->restore($this->entity->id);
 
         $this->assertEquals(204, $response->getStatusCode());
     }
 
     protected function createEntity()
     {
-        $this->post = $this->createPost($this->blogPostsResource);
+        $this->post = $this->createPost($this->blogPostsEndpoint);
 
         sleep(1);
 
-        return $this->resource->create([
+        return $this->endpoint->create([
             'comment' => 'This is a test blog comment',
             'contentId' => $this->post->id,
             'collectionId' => $this->blogId,
@@ -108,11 +108,11 @@ class BlogCommentsTest extends BlogPostTestCase
 
     protected function deleteEntity()
     {
-        return $this->resource->delete($this->entity->id);
+        return $this->endpoint->delete($this->entity->id);
     }
 
     protected function deletePost()
     {
-        return $this->blogPostsResource->delete($this->post->id);
+        return $this->blogPostsEndpoint->delete($this->post->id);
     }
 }

--- a/tests/Integration/Endpoints/BlogPostsTest.php
+++ b/tests/Integration/Endpoints/BlogPostsTest.php
@@ -14,17 +14,17 @@ class BlogPostsTest extends BlogPostTestCase
     /**
      * @var BlogPosts::class
      */
-    protected $resourceClass = BlogPosts::class;
+    protected $endpointClass = BlogPosts::class;
 
     /**
      * @var BlogPosts
      */
-    protected $resource;
+    protected $endpoint;
 
     /** @test */
     public function allWithNoParams()
     {
-        $response = $this->resource->all();
+        $response = $this->endpoint->all();
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -32,7 +32,7 @@ class BlogPostsTest extends BlogPostTestCase
     /** @test */
     public function allWithParams()
     {
-        $response = $this->resource->all([
+        $response = $this->endpoint->all([
             'limit' => 2,
             'offset' => 3,
         ]);
@@ -45,7 +45,7 @@ class BlogPostsTest extends BlogPostTestCase
     /** @test */
     public function allWithParamsAndArrayAccess()
     {
-        $response = $this->resource->all([
+        $response = $this->endpoint->all([
             'limit' => 2,
             'offset' => 3,
         ]);
@@ -58,7 +58,7 @@ class BlogPostsTest extends BlogPostTestCase
     /** @test */
     public function getById()
     {
-        $response = $this->resource->getById($this->entity->id);
+        $response = $this->endpoint->getById($this->entity->id);
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -72,7 +72,7 @@ class BlogPostsTest extends BlogPostTestCase
     /** @test */
     public function update()
     {
-        $response = $this->resource->update($this->entity->id, [
+        $response = $this->endpoint->update($this->entity->id, [
             'post_body' => '<p>Hey man!</p>',
         ]);
 
@@ -92,17 +92,17 @@ class BlogPostsTest extends BlogPostTestCase
     /** @test */
     public function clonePost()
     {
-        $response = $this->resource->clone($this->entity->id, 'Cloned post name');
+        $response = $this->endpoint->clone($this->entity->id, 'Cloned post name');
 
         $this->assertEquals(201, $response->getStatusCode());
 
-        $this->resource->delete($response->id);
+        $this->endpoint->delete($response->id);
     }
 
     /** @test */
     public function publishAction()
     {
-        $response = $this->resource->publishAction($this->entity->id, 'schedule-publish');
+        $response = $this->endpoint->publishAction($this->entity->id, 'schedule-publish');
 
         $this->assertEquals(204, $response->getStatusCode());
     }
@@ -110,7 +110,7 @@ class BlogPostsTest extends BlogPostTestCase
     /** @test */
     public function getAutoSaveBufferContents()
     {
-        $response = $this->resource->getAutoSaveBufferContents($this->entity->id);
+        $response = $this->endpoint->getAutoSaveBufferContents($this->entity->id);
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -118,7 +118,7 @@ class BlogPostsTest extends BlogPostTestCase
     /** @test */
     public function updateAutoSaveBuffer()
     {
-        $response = $this->resource->updateAutoSaveBuffer($this->entity->id, [
+        $response = $this->endpoint->updateAutoSaveBuffer($this->entity->id, [
             'post_body' => '<p>Hey! It is a test!</p>',
         ]);
 
@@ -128,7 +128,7 @@ class BlogPostsTest extends BlogPostTestCase
     /** @test */
     public function hasBufferedChanges()
     {
-        $response = $this->resource->hasBufferedChanges($this->entity->id);
+        $response = $this->endpoint->hasBufferedChanges($this->entity->id);
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertFalse($response->has_changes);
@@ -137,7 +137,7 @@ class BlogPostsTest extends BlogPostTestCase
     /** @test */
     public function validateBuffer()
     {
-        $response = $this->resource->validateBuffer($this->entity->id);
+        $response = $this->endpoint->validateBuffer($this->entity->id);
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertTrue($response->succeeded);
@@ -146,7 +146,7 @@ class BlogPostsTest extends BlogPostTestCase
     /** @test */
     public function pushBufferLive()
     {
-        $response = $this->resource->pushBufferLive($this->entity->id);
+        $response = $this->endpoint->pushBufferLive($this->entity->id);
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -155,7 +155,7 @@ class BlogPostsTest extends BlogPostTestCase
     public function restoreDeleted()
     {
         $this->deleteEntity();
-        $response = $this->resource->restoreDeleted($this->entity->id);
+        $response = $this->endpoint->restoreDeleted($this->entity->id);
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -163,7 +163,7 @@ class BlogPostsTest extends BlogPostTestCase
     /** @test */
     public function versions()
     {
-        $response = $this->resource->versions($this->entity->id);
+        $response = $this->endpoint->versions($this->entity->id);
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -171,15 +171,15 @@ class BlogPostsTest extends BlogPostTestCase
     /** @test */
     public function getVersion()
     {
-        $this->resource->update($this->entity->id, [
+        $this->endpoint->update($this->entity->id, [
             'post_body' => '<p>Hey! It is a test!</p>',
         ]);
 
-        $listResponse = $this->resource->versions($this->entity->id);
+        $listResponse = $this->endpoint->versions($this->entity->id);
 
         $versionId = $listResponse->getData()[1]->id;
 
-        $response = $this->resource->getVersion($this->entity->id, $versionId);
+        $response = $this->endpoint->getVersion($this->entity->id, $versionId);
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -187,26 +187,26 @@ class BlogPostsTest extends BlogPostTestCase
     /** @test */
     public function restoreVersion()
     {
-        $this->resource->update($this->entity->id, [
+        $this->endpoint->update($this->entity->id, [
             'post_body' => '<p>Hey! It is a test!</p>',
         ]);
 
-        $listResponse = $this->resource->versions($this->entity->id);
+        $listResponse = $this->endpoint->versions($this->entity->id);
 
         $versionId = $listResponse->getData()[1]->id;
 
-        $response = $this->resource->restoreVersion($this->entity->id, $versionId);
+        $response = $this->endpoint->restoreVersion($this->entity->id, $versionId);
 
         $this->assertEquals(200, $response->getStatusCode());
     }
 
     protected function createEntity()
     {
-        return $this->createPost($this->resource);
+        return $this->createPost($this->endpoint);
     }
 
     protected function deleteEntity()
     {
-        return $this->resource->delete($this->entity->id);
+        return $this->endpoint->delete($this->entity->id);
     }
 }

--- a/tests/Integration/Endpoints/BlogTopicsTest.php
+++ b/tests/Integration/Endpoints/BlogTopicsTest.php
@@ -14,17 +14,17 @@ class BlogTopicsTest extends EntityTestCase
     /**
      * @var BlogTopics::class
      */
-    protected $resourceClass = BlogTopics::class;
+    protected $endpointClass = BlogTopics::class;
 
     /**
      * @var BlogTopics
      */
-    protected $resource;
+    protected $endpoint;
 
     /** @test */
     public function allWithNoParams()
     {
-        $response = $this->resource->all();
+        $response = $this->endpoint->all();
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -32,7 +32,7 @@ class BlogTopicsTest extends EntityTestCase
     /** @test */
     public function allWithParams()
     {
-        $response = $this->resource->all([
+        $response = $this->endpoint->all([
             'limit' => 2,
             'offset' => 3,
         ]);
@@ -45,7 +45,7 @@ class BlogTopicsTest extends EntityTestCase
     /** @test */
     public function searchWithoutQueryAndParams()
     {
-        $response = $this->resource->search('');
+        $response = $this->endpoint->search('');
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -53,7 +53,7 @@ class BlogTopicsTest extends EntityTestCase
     /** @test */
     public function searchWithQueryAndWithoutParams()
     {
-        $response = $this->resource->search('Test');
+        $response = $this->endpoint->search('Test');
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -61,7 +61,7 @@ class BlogTopicsTest extends EntityTestCase
     /** @test */
     public function searchWithQueryAndParams()
     {
-        $response = $this->resource->search('Test', [
+        $response = $this->endpoint->search('Test', [
             'limit' => 5,
         ]);
 
@@ -72,7 +72,7 @@ class BlogTopicsTest extends EntityTestCase
     /** @test */
     public function getById()
     {
-        $response = $this->resource->getById($this->entity->id);
+        $response = $this->endpoint->getById($this->entity->id);
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -86,7 +86,7 @@ class BlogTopicsTest extends EntityTestCase
     /** @test */
     public function update()
     {
-        $response = $this->resource->update($this->entity->id, [
+        $response = $this->endpoint->update($this->entity->id, [
             'name' => 'Topic Test '.uniqid().' Updated',
             'description' => 'Topic Test '.uniqid().' Description Updated',
         ]);
@@ -106,7 +106,7 @@ class BlogTopicsTest extends EntityTestCase
 
     protected function createEntity()
     {
-        return $this->resource->create([
+        return $this->endpoint->create([
             'name' => 'Topic Test '.uniqid(),
             'description' => 'Topic Test '.uniqid().' Description',
         ]);
@@ -114,6 +114,6 @@ class BlogTopicsTest extends EntityTestCase
 
     protected function deleteEntity()
     {
-        return $this->resource->delete($this->entity->id);
+        return $this->endpoint->delete($this->entity->id);
     }
 }

--- a/tests/Integration/Endpoints/BlogsTest.php
+++ b/tests/Integration/Endpoints/BlogsTest.php
@@ -14,17 +14,17 @@ class BlogsTest extends DefaultTestCase
     /**
      * @var Blogs
      */
-    protected $resource;
+    protected $endpoint;
 
     /**
      * @var Blogs::class
      */
-    protected $resourceClass = Blogs::class;
+    protected $endpointClass = Blogs::class;
 
     /** @test */
     public function allWithNoParams()
     {
-        $response = $this->resource->all();
+        $response = $this->endpoint->all();
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -32,7 +32,7 @@ class BlogsTest extends DefaultTestCase
     /** @test */
     public function allWithParams()
     {
-        $response = $this->resource->all(['limit' => 1]);
+        $response = $this->endpoint->all(['limit' => 1]);
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertNotNull($response->objects[0]->created);
@@ -41,7 +41,7 @@ class BlogsTest extends DefaultTestCase
     /** @test */
     public function allWithParamsAndArrayAccess()
     {
-        $response = $this->resource->all(['limit' => 1]);
+        $response = $this->endpoint->all(['limit' => 1]);
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertNotNull($response['objects'][0]['created']);
@@ -50,9 +50,9 @@ class BlogsTest extends DefaultTestCase
     /** @test */
     public function getById()
     {
-        $blogs = $this->resource->all(['limit' => 1]);
+        $blogs = $this->endpoint->all(['limit' => 1]);
 
-        $response = $this->resource->getById($blogs->objects[0]->id);
+        $response = $this->endpoint->getById($blogs->objects[0]->id);
 
         $this->assertEquals(200, $response->getStatusCode());
     }

--- a/tests/Integration/Endpoints/CalendarEventsTest.php
+++ b/tests/Integration/Endpoints/CalendarEventsTest.php
@@ -16,17 +16,17 @@ class CalendarEventsTest extends EntityTestCase
     /**
      * @var CalendarEvents
      */
-    protected $resource;
+    protected $endpoint;
 
     /**
      * @var CalendarEvents::class
      */
-    protected $resourceClass = CalendarEvents::class;
+    protected $endpointClass = CalendarEvents::class;
 
     /**
      * @var Owners
      */
-    protected $ownersResource;
+    protected $ownersEndpoint;
 
     /**
      * @var stdClass
@@ -35,8 +35,8 @@ class CalendarEventsTest extends EntityTestCase
 
     public function setUp(): void
     {
-        $this->ownersResource = new Owners($this->getClient());
-        $response = $this->ownersResource->all(['email' => getenv('HUBSPOT_TEST_EMAIL')]);
+        $this->ownersEndpoint = new Owners($this->getClient());
+        $response = $this->ownersEndpoint->all(['email' => getenv('HUBSPOT_TEST_EMAIL')]);
         if (empty($response->getData())) {
             throw new Exception('Invalid Email (HUBSPOT_TEST_EMAIL)');
         }
@@ -59,7 +59,7 @@ class CalendarEventsTest extends EntityTestCase
      */
     public function updateTask()
     {
-        $response = $this->resource->updateTask($this->entity->id, [
+        $response = $this->endpoint->updateTask($this->entity->id, [
             'name' => 'Another name',
             'description' => 'Another description',
         ]);
@@ -72,7 +72,7 @@ class CalendarEventsTest extends EntityTestCase
      */
     public function getTaskById()
     {
-        $response = $this->resource->getTaskById($this->entity->id);
+        $response = $this->endpoint->getTaskById($this->entity->id);
 
         $this->assertSame(200, $response->getStatusCode());
         $this->assertEquals($this->entity->name, $response->name);
@@ -97,7 +97,7 @@ class CalendarEventsTest extends EntityTestCase
         $startDate = $this->entity->eventDate - 60 * 60 * 1000;
         $endDate = $this->entity->eventDate + 60 * 60 * 1000;
 
-        $response = $this->resource->all($startDate, $endDate);
+        $response = $this->endpoint->all($startDate, $endDate);
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertGreaterThanOrEqual(1, count($response->getData()));
@@ -110,7 +110,7 @@ class CalendarEventsTest extends EntityTestCase
         $startDate = $this->entity->eventDate - 60 * 60 * 1000;
         $endDate = $this->entity->eventDate + 60 * 60 * 1000;
 
-        $response = $this->resource->allTasks($startDate, $endDate);
+        $response = $this->endpoint->allTasks($startDate, $endDate);
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertGreaterThanOrEqual(1, count($response->toArray()));
@@ -118,7 +118,7 @@ class CalendarEventsTest extends EntityTestCase
 
     protected function createEntity()
     {
-        return $this->resource->createTask([
+        return $this->endpoint->createTask([
             'eventDate' => strtotime('+1 day') * 1000, // timestamp in milliseconds
             'eventType' => 'PUBLISHING_TASK',
             'category' => 'EMAIL',
@@ -131,6 +131,6 @@ class CalendarEventsTest extends EntityTestCase
 
     protected function deleteEntity()
     {
-        return $this->resource->deleteTask($this->entity->id);
+        return $this->endpoint->deleteTask($this->entity->id);
     }
 }

--- a/tests/Integration/Endpoints/CompaniesTest.php
+++ b/tests/Integration/Endpoints/CompaniesTest.php
@@ -19,21 +19,21 @@ class CompaniesTest extends EntityTestCase
     /**
      * @var Companies
      */
-    protected $resource;
+    protected $endpoint;
 
     /**
      * @var Companies::class
      */
-    protected $resourceClass = Companies::class;
+    protected $endpointClass = Companies::class;
 
     /**
      * @var Contacts
      */
-    protected $contactsResource;
+    protected $contactsEndpoint;
 
     public function setUp(): void
     {
-        $this->contactsResource = new Contacts($this->getClient());
+        $this->contactsEndpoint = new Contacts($this->getClient());
         parent::setUp();
     }
 
@@ -55,7 +55,7 @@ class CompaniesTest extends EntityTestCase
             'value' => $companyDescription,
         ];
 
-        $response = $this->resource->update($this->entity->companyId, $properties);
+        $response = $this->endpoint->update($this->entity->companyId, $properties);
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals($this->entity->companyId, $response->companyId);
@@ -79,7 +79,7 @@ class CompaniesTest extends EntityTestCase
             ],
         ];
 
-        $response = $this->resource->updateBatch($companies);
+        $response = $this->endpoint->updateBatch($companies);
 
         $this->assertEquals(202, $response->getStatusCode());
     }
@@ -99,7 +99,7 @@ class CompaniesTest extends EntityTestCase
     /** @test */
     public function getAll()
     {
-        $response = $this->resource->all();
+        $response = $this->endpoint->all();
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertGreaterThan(0, count($response->data->companies));
@@ -108,7 +108,7 @@ class CompaniesTest extends EntityTestCase
     /** @test */
     public function getRecentlyModified()
     {
-        $response = $this->resource->getRecentlyModified();
+        $response = $this->endpoint->getRecentlyModified();
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertGreaterThan(2, $response['results']);
@@ -118,7 +118,7 @@ class CompaniesTest extends EntityTestCase
     public function getRecentlyModifiedWithCountAndOffset()
     {
         $params = ['count' => 2, 'offset' => 1];
-        $response = $this->resource->getRecentlyModified($params);
+        $response = $this->endpoint->getRecentlyModified($params);
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertCount(2, $response['results']);
         $this->assertEquals(3, $response['offset']);
@@ -127,7 +127,7 @@ class CompaniesTest extends EntityTestCase
     /** @test */
     public function getRecentlyCreated()
     {
-        $response = $this->resource->getRecentlyCreated();
+        $response = $this->endpoint->getRecentlyCreated();
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertGreaterThan(2, $response['results']);
@@ -137,7 +137,7 @@ class CompaniesTest extends EntityTestCase
     public function getRecentlyCreatedWithCountAndOffset()
     {
         $params = ['count' => 2, 'offset' => 1];
-        $response = $this->resource->getRecentlyCreated($params);
+        $response = $this->endpoint->getRecentlyCreated($params);
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -145,7 +145,7 @@ class CompaniesTest extends EntityTestCase
     /** @test */
     public function getById()
     {
-        $response = $this->resource->getById($this->entity->companyId);
+        $response = $this->endpoint->getById($this->entity->companyId);
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals($this->entity->companyId, $response->companyId);
@@ -160,11 +160,11 @@ class CompaniesTest extends EntityTestCase
             'name' => 'description',
             'value' => $newDescription,
         ];
-        $response = $this->resource->update($this->entity->companyId, $properties);
+        $response = $this->endpoint->update($this->entity->companyId, $properties);
 
         // Get multiple versions for property
         $params = ['includePropertyVersions' => true];
-        $response = $this->resource->getById($this->entity->companyId, $params);
+        $response = $this->endpoint->getById($this->entity->companyId, $params);
         $this->assertCount(2, $response->getData()->properties->description->versions);
     }
 
@@ -173,7 +173,7 @@ class CompaniesTest extends EntityTestCase
     {
         list($contactId) = $this->createAssociatedContact($this->entity->companyId);
 
-        $response = $this->resource->getAssociatedContacts($this->entity->companyId);
+        $response = $this->endpoint->getAssociatedContacts($this->entity->companyId);
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertCount(1, $response->contacts);
@@ -188,11 +188,11 @@ class CompaniesTest extends EntityTestCase
         list($contactId) = $this->createAssociatedContact($this->entity->companyId);
         list($contactId2) = $this->createAssociatedContact($this->entity->companyId);
 
-        $response = $this->resource->getAssociatedContacts($this->entity->companyId, ['count' => 1]);
+        $response = $this->endpoint->getAssociatedContacts($this->entity->companyId, ['count' => 1]);
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertCount(1, $response->contacts);
 
-        $offsetResponse = $this->resource->getAssociatedContacts($this->entity->companyId, ['count' => 1, 'vidOffset' => $contactId]);
+        $offsetResponse = $this->endpoint->getAssociatedContacts($this->entity->companyId, ['count' => 1, 'vidOffset' => $contactId]);
         $this->assertEquals(200, $offsetResponse->getStatusCode());
         $this->assertGreaterThanOrEqual($contactId2, $offsetResponse->vidOffset);
 
@@ -205,7 +205,7 @@ class CompaniesTest extends EntityTestCase
         list($contactId1) = $this->createAssociatedContact($this->entity->companyId);
         list($contactId2) = $this->createAssociatedContact($this->entity->companyId);
 
-        $response = $this->resource->getAssociatedContactIds($this->entity->companyId);
+        $response = $this->endpoint->getAssociatedContactIds($this->entity->companyId);
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertGreaterThanOrEqual(1, $response->vids);
@@ -221,11 +221,11 @@ class CompaniesTest extends EntityTestCase
         list($contactId1) = $this->createAssociatedContact($this->entity->companyId);
         list($contactId2) = $this->createAssociatedContact($this->entity->companyId);
 
-        $response = $this->resource->getAssociatedContactIds($this->entity->companyId, ['count' => 1]);
+        $response = $this->endpoint->getAssociatedContactIds($this->entity->companyId, ['count' => 1]);
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertCount(1, $response->vids);
 
-        $offsetResponse = $this->resource->getAssociatedContactIds($this->entity->companyId, ['count' => 1, 'vidOffset' => $contactId1]);
+        $offsetResponse = $this->endpoint->getAssociatedContactIds($this->entity->companyId, ['count' => 1, 'vidOffset' => $contactId1]);
         $this->assertEquals(200, $offsetResponse->getStatusCode());
         $this->assertGreaterThanOrEqual($contactId2, $offsetResponse->vidOffset);
 
@@ -237,11 +237,11 @@ class CompaniesTest extends EntityTestCase
     {
         list($contactId) = $this->createAssociatedContact($this->entity->companyId);
 
-        $response = $this->resource->removeContact($contactId, $this->entity->companyId);
+        $response = $this->endpoint->removeContact($contactId, $this->entity->companyId);
 
         $this->assertEquals(204, $response->getStatusCode());
 
-        $this->contactsResource->delete($contactId);
+        $this->contactsEndpoint->delete($contactId);
     }
 
     /**
@@ -249,7 +249,7 @@ class CompaniesTest extends EntityTestCase
      */
     public function searchCompanyByDomain()
     {
-        $response = $this->resource->searchByDomain('example.com', ['name', 'domain']);
+        $response = $this->endpoint->searchByDomain('example.com', ['name', 'domain']);
         $this->assertEquals(200, $response->getStatusCode());
         $results = $response->getData()->results;
         $this->assertEquals('example.com', current($results)->properties->domain->value);
@@ -262,7 +262,7 @@ class CompaniesTest extends EntityTestCase
      */
     protected function createContact()
     {
-        $response = $this->contactsResource->create([
+        $response = $this->contactsEndpoint->create([
             ['property' => 'email', 'value' => 'rw_test'.uniqid().'@hubspot.com'],
             ['property' => 'firstname', 'value' => 'joe'],
             ['property' => 'lastname', 'value' => 'user'],
@@ -284,7 +284,7 @@ class CompaniesTest extends EntityTestCase
     {
         $contact = $this->createContact();
 
-        $response = $this->resource->addContact($contact->vid, $companyId);
+        $response = $this->endpoint->addContact($contact->vid, $companyId);
 
         sleep(1);
 
@@ -294,15 +294,15 @@ class CompaniesTest extends EntityTestCase
     protected function deleteAssociatedContacts($companyId, $contactIds = [])
     {
         foreach ($contactIds as $contactId) {
-            $this->resource->removeContact($contactId, $companyId);
+            $this->endpoint->removeContact($contactId, $companyId);
             sleep(1);
-            $this->contactsResource->delete($contactId);
+            $this->contactsEndpoint->delete($contactId);
         }
     }
 
     protected function createEntity()
     {
-        return $this->resource->create([
+        return $this->endpoint->create([
             [
                 'name' => 'name',
                 'value' => 'A company name',
@@ -320,6 +320,6 @@ class CompaniesTest extends EntityTestCase
 
     protected function deleteEntity()
     {
-        return $this->resource->delete($this->entity->companyId);
+        return $this->endpoint->delete($this->entity->companyId);
     }
 }

--- a/tests/Integration/Endpoints/CompanyPropertiesTest.php
+++ b/tests/Integration/Endpoints/CompanyPropertiesTest.php
@@ -14,7 +14,7 @@ class CompanyPropertiesTest extends PropertiesTestCase
     /**
      * @var null|SevenShores\Hubspot\Endpoints\Endpoint
      */
-    protected $resourceClass = CompanyProperties::class;
+    protected $endpointClass = CompanyProperties::class;
 
     /**
      * @var string

--- a/tests/Integration/Endpoints/CompanyPropertyGroupsTest.php
+++ b/tests/Integration/Endpoints/CompanyPropertyGroupsTest.php
@@ -14,5 +14,5 @@ class CompanyPropertyGroupsTest extends PropertyGroupsTestCase
     /**
      * @var CompanyProperties
      */
-    protected $resourceClass = CompanyProperties::class;
+    protected $endpointClass = CompanyProperties::class;
 }

--- a/tests/Integration/Endpoints/ContactDinamicListsTest.php
+++ b/tests/Integration/Endpoints/ContactDinamicListsTest.php
@@ -19,19 +19,19 @@ class ContactDinamicListsTest extends ContactListsTestCase
     /**
      * @var Contacts
      */
-    protected $contactsResource;
+    protected $contactsEndpoint;
 
     public function setUp(): void
     {
         parent::setUp();
 
-        $this->contactsResource = new Contacts($this->getClient());
+        $this->contactsEndpoint = new Contacts($this->getClient());
     }
 
     /** @test */
     public function getAllDynamic()
     {
-        $response = $this->resource->getAllStatic();
+        $response = $this->endpoint->getAllStatic();
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -41,13 +41,13 @@ class ContactDinamicListsTest extends ContactListsTestCase
     {
         $contact = $this->createContact();
 
-        $response = $this->resource->addContact($this->entity->listId, [$contact->vid]);
+        $response = $this->endpoint->addContact($this->entity->listId, [$contact->vid]);
 
         $this->assertEquals(200, $response->getStatusCode());
 
-        $this->resource->removeContact($this->entity->listId, [$contact->vid]);
+        $this->endpoint->removeContact($this->entity->listId, [$contact->vid]);
 
-        $this->contactsResource->delete($contact->vid);
+        $this->contactsEndpoint->delete($contact->vid);
     }
 
     /** @test */
@@ -55,13 +55,13 @@ class ContactDinamicListsTest extends ContactListsTestCase
     {
         $contact = $this->createContact();
 
-        $this->resource->addContact($this->entity->listId, [$contact->vid]);
+        $this->endpoint->addContact($this->entity->listId, [$contact->vid]);
 
-        $response = $this->resource->removeContact($this->entity->listId, [$contact->vid]);
+        $response = $this->endpoint->removeContact($this->entity->listId, [$contact->vid]);
 
         $this->assertEquals(200, $response->getStatusCode());
 
-        $this->contactsResource->delete($contact->vid);
+        $this->contactsEndpoint->delete($contact->vid);
     }
 
     /**
@@ -71,7 +71,7 @@ class ContactDinamicListsTest extends ContactListsTestCase
      */
     protected function createContact()
     {
-        $contactResponse = $this->contactsResource->create([
+        $contactResponse = $this->contactsEndpoint->create([
             ['property' => 'email', 'value' => 'ContactListsTest'.uniqid().'@hubspot.com'],
             ['property' => 'firstname', 'value' => 'joe'],
             ['property' => 'lastname', 'value' => 'user'],

--- a/tests/Integration/Endpoints/ContactListsTest.php
+++ b/tests/Integration/Endpoints/ContactListsTest.php
@@ -14,17 +14,17 @@ class ContactListsTest extends ContactListsTestCase
     /**
      * @var ContactLists
      */
-    protected $resource;
+    protected $endpoint;
 
     /**
      * @var ContactLists::class
      */
-    protected $resourceClass = ContactLists::class;
+    protected $endpointClass = ContactLists::class;
 
     /** @test */
     public function allWithNoParams()
     {
-        $response = $this->resource->all();
+        $response = $this->endpoint->all();
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -32,7 +32,7 @@ class ContactListsTest extends ContactListsTestCase
     /** @test */
     public function getAllStatic()
     {
-        $response = $this->resource->getAllStatic();
+        $response = $this->endpoint->getAllStatic();
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -40,7 +40,7 @@ class ContactListsTest extends ContactListsTestCase
     /** @test */
     public function update()
     {
-        $response = $this->resource->update($this->entity->listId, [
+        $response = $this->endpoint->update($this->entity->listId, [
             'name' => 'New test name '.uniqid(),
         ]);
 
@@ -50,7 +50,7 @@ class ContactListsTest extends ContactListsTestCase
     /** @test */
     public function getById()
     {
-        $response = $this->resource->getById($this->entity->listId);
+        $response = $this->endpoint->getById($this->entity->listId);
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -65,17 +65,17 @@ class ContactListsTest extends ContactListsTestCase
             $list->listId,
         ];
 
-        $response = $this->resource->getBatchByIds($ids);
+        $response = $this->endpoint->getBatchByIds($ids);
 
         $this->assertEquals(200, $response->getStatusCode());
 
-        $this->resource->delete($list->listId);
+        $this->endpoint->delete($list->listId);
     }
 
     /** @test */
     public function contacts()
     {
-        $response = $this->resource->contacts($this->entity->listId);
+        $response = $this->endpoint->contacts($this->entity->listId);
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -83,7 +83,7 @@ class ContactListsTest extends ContactListsTestCase
     /** @test */
     public function recentContacts()
     {
-        $response = $this->resource->recentContacts($this->entity->listId);
+        $response = $this->endpoint->recentContacts($this->entity->listId);
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -91,7 +91,7 @@ class ContactListsTest extends ContactListsTestCase
     /** @test */
     public function delete()
     {
-        $response = $this->resource->delete($this->entity->listId);
+        $response = $this->endpoint->delete($this->entity->listId);
 
         $this->assertEquals(204, $response->getStatusCode());
 

--- a/tests/Integration/Endpoints/ContactPropertiesTest.php
+++ b/tests/Integration/Endpoints/ContactPropertiesTest.php
@@ -14,7 +14,7 @@ class ContactPropertiesTest extends PropertiesTestCase
     /**
      * @var null|SevenShores\Hubspot\Endpoints\Endpoint
      */
-    protected $resourceClass = ContactProperties::class;
+    protected $endpointClass = ContactProperties::class;
 
     /**
      * @var string

--- a/tests/Integration/Endpoints/ContactPropertyGroupsTest.php
+++ b/tests/Integration/Endpoints/ContactPropertyGroupsTest.php
@@ -19,5 +19,5 @@ class ContactPropertyGroupsTest extends PropertyGroupsTestCase
     /**
      * @var ContactProperties
      */
-    protected $resourceClass = ContactProperties::class;
+    protected $endpointClass = ContactProperties::class;
 }

--- a/tests/Integration/Endpoints/ContactsTest.php
+++ b/tests/Integration/Endpoints/ContactsTest.php
@@ -14,17 +14,17 @@ class ContactsTest extends EntityTestCase
     /**
      * @var SevenShores\Hubspot\Endpoints\Contacts
      */
-    protected $resource;
+    protected $endpoint;
 
     /**
      * @var SevenShores\Hubspot\Endpoints\Contacts::class
      */
-    protected $resourceClass = Contacts::class;
+    protected $endpointClass = Contacts::class;
 
     /** @test */
     public function allWithNoParams()
     {
-        $response = $this->resource->all();
+        $response = $this->endpoint->all();
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertGreaterThanOrEqual(1, count($response->contacts));
@@ -33,7 +33,7 @@ class ContactsTest extends EntityTestCase
     /** @test */
     public function allWithParams()
     {
-        $response = $this->resource->all([
+        $response = $this->endpoint->all([
             'property' => ['firstname', 'lastname'],
         ]);
 
@@ -44,7 +44,7 @@ class ContactsTest extends EntityTestCase
     /** @test */
     public function allWithParamsAndArrayAccess()
     {
-        $response = $this->resource->all([
+        $response = $this->endpoint->all([
             'property' => ['firstname', 'lastname'],
         ]);
 
@@ -61,7 +61,7 @@ class ContactsTest extends EntityTestCase
     /** @test */
     public function update()
     {
-        $response = $this->resource->update($this->entity->vid, [
+        $response = $this->endpoint->update($this->entity->vid, [
             ['property' => 'firstname', 'value' => 'joe'],
             ['property' => 'lastname', 'value' => 'user'],
         ]);
@@ -72,7 +72,7 @@ class ContactsTest extends EntityTestCase
     /** @test */
     public function updateByEmail()
     {
-        $response = $this->resource->updateByEmail($this->entity->properties->email->value, [
+        $response = $this->endpoint->updateByEmail($this->entity->properties->email->value, [
             ['property' => 'firstname', 'value' => 'joe'],
             ['property' => 'lastname', 'value' => 'user'],
         ]);
@@ -84,7 +84,7 @@ class ContactsTest extends EntityTestCase
     public function createOrUpdate()
     {
         sleep(2);
-        $response = $this->resource->createOrUpdate($this->entity->properties->email->value, [
+        $response = $this->endpoint->createOrUpdate($this->entity->properties->email->value, [
             ['property' => 'firstname', 'value' => 'joe'],
             ['property' => 'lastname', 'value' => 'user'],
         ]);
@@ -96,7 +96,7 @@ class ContactsTest extends EntityTestCase
     public function createOrUpdateBatch()
     {
         $secondEmail = 'test2@hubspot.com';
-        $response = $this->resource->createOrUpdateBatch([
+        $response = $this->endpoint->createOrUpdateBatch([
             [
                 'email' => $this->entity->properties->email->value,
                 'properties' => [
@@ -115,15 +115,15 @@ class ContactsTest extends EntityTestCase
         $this->assertEquals(202, $response->getStatusCode());
 
         sleep(1);
-        $contact = $this->resource->getByEmail($secondEmail)->getData();
-        $this->resource->delete($contact->vid);
+        $contact = $this->endpoint->getByEmail($secondEmail)->getData();
+        $this->endpoint->delete($contact->vid);
     }
 
     /** @test */
     public function createOrUpdateBatchWithAuditId()
     {
         $emails = ['testWithAuditId3@hubspot.com', 'testWithAuditId4@hubspot.com'];
-        $response = $this->resource->createOrUpdateBatch([
+        $response = $this->endpoint->createOrUpdateBatch([
             [
                 'email' => $emails[0],
                 'properties' => [
@@ -141,8 +141,8 @@ class ContactsTest extends EntityTestCase
         ], ['auditId' => 'TEST_CHANGE_SOURCE']);
         $this->assertEquals(202, $response->getStatusCode());
 
-        foreach ($this->resource->getBatchByEmails($emails)->getData() as $contact) {
-            $this->resource->delete($contact->vid);
+        foreach ($this->endpoint->getBatchByEmails($emails)->getData() as $contact) {
+            $this->endpoint->delete($contact->vid);
         }
     }
 
@@ -159,7 +159,7 @@ class ContactsTest extends EntityTestCase
     /** @test */
     public function recent()
     {
-        $response = $this->resource->recent(['count' => 2]);
+        $response = $this->endpoint->recent(['count' => 2]);
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -167,7 +167,7 @@ class ContactsTest extends EntityTestCase
     /** @test */
     public function getById()
     {
-        $response = $this->resource->getById($this->entity->vid);
+        $response = $this->endpoint->getById($this->entity->vid);
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -182,17 +182,17 @@ class ContactsTest extends EntityTestCase
             $contact->vid,
         ];
 
-        $response = $this->resource->getBatchByIds($ids);
+        $response = $this->endpoint->getBatchByIds($ids);
 
         $this->assertEquals(200, $response->getStatusCode());
 
-        $this->resource->delete($contact->vid);
+        $this->endpoint->delete($contact->vid);
     }
 
     /** @test */
     public function getByEmail()
     {
-        $response = $this->resource->getByEmail($this->entity->properties->email->value);
+        $response = $this->endpoint->getByEmail($this->entity->properties->email->value);
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -207,17 +207,17 @@ class ContactsTest extends EntityTestCase
             $contact->properties->email->value,
         ];
 
-        $response = $this->resource->getBatchByEmails($emails);
+        $response = $this->endpoint->getBatchByEmails($emails);
 
         $this->assertEquals(200, $response->getStatusCode());
 
-        $this->resource->delete($contact->vid);
+        $this->endpoint->delete($contact->vid);
     }
 
     /** @test */
     public function search()
     {
-        $response = $this->resource->search('hub', ['count' => 2]);
+        $response = $this->endpoint->search('hub', ['count' => 2]);
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -225,7 +225,7 @@ class ContactsTest extends EntityTestCase
     /** @test */
     public function statistics()
     {
-        $response = $this->resource->statistics();
+        $response = $this->endpoint->statistics();
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -235,7 +235,7 @@ class ContactsTest extends EntityTestCase
     {
         $secondaryEmail = 'rw_test'.uniqid().'@hubspot.com';
 
-        $response = $this->resource->addSecondaryEmail($this->entity->vid, $secondaryEmail);
+        $response = $this->endpoint->addSecondaryEmail($this->entity->vid, $secondaryEmail);
         $this->assertEquals(200, $response->getStatusCode());
     }
 
@@ -244,26 +244,26 @@ class ContactsTest extends EntityTestCase
     {
         $secondaryEmail = 'rw_test'.uniqid().'@hubspot.com';
 
-        $response = $this->resource->addSecondaryEmail($this->entity->vid, $secondaryEmail);
+        $response = $this->endpoint->addSecondaryEmail($this->entity->vid, $secondaryEmail);
         $this->assertEquals(200, $response->getStatusCode());
 
         sleep(1);
 
-        $response = $this->resource->deleteSecondaryEmail($this->entity->vid, $secondaryEmail);
+        $response = $this->endpoint->deleteSecondaryEmail($this->entity->vid, $secondaryEmail);
         $this->assertEquals(200, $response->getStatusCode());
     }
 
     /** @test */
     public function getLifecycleStageMetrics()
     {
-        $response = $this->resource->getLifecycleStageMetrics();
+        $response = $this->endpoint->getLifecycleStageMetrics();
 
         $this->assertEquals(200, $response->getStatusCode());
     }
 
     protected function createEntity()
     {
-        return $this->resource->create([
+        return $this->endpoint->create([
             ['property' => 'email',     'value' => 'rw_test'.uniqid().'@hubspot.com'],
             ['property' => 'firstname', 'value' => 'joe'],
             ['property' => 'lastname',  'value' => 'user'],
@@ -272,6 +272,6 @@ class ContactsTest extends EntityTestCase
 
     protected function deleteEntity()
     {
-        return $this->resource->delete($this->entity->vid);
+        return $this->endpoint->delete($this->entity->vid);
     }
 }

--- a/tests/Integration/Endpoints/DealPipelinesTest.php
+++ b/tests/Integration/Endpoints/DealPipelinesTest.php
@@ -15,12 +15,12 @@ class DealPipelinesTest extends EntityTestCase
     /**
      * @var DealPipelines
      */
-    protected $resource;
+    protected $endpoint;
 
     /**
      * @var DealPipelines::class
      */
-    protected $resourceClass = DealPipelines::class;
+    protected $endpointClass = DealPipelines::class;
 
     /**
      * @var null|\SevenShores\Hubspot\Http\Response
@@ -41,7 +41,7 @@ class DealPipelinesTest extends EntityTestCase
      */
     public function getAllPipelines()
     {
-        $response = $this->resource->getAllPipelines();
+        $response = $this->endpoint->getAllPipelines();
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertGreaterThanOrEqual(1, count($response->getData()));
@@ -52,7 +52,7 @@ class DealPipelinesTest extends EntityTestCase
      */
     public function getPipeline()
     {
-        $response = $this->resource->getPipeline($this->entity->pipelineId);
+        $response = $this->endpoint->getPipeline($this->entity->pipelineId);
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals($this->entity->label, $response->label);
@@ -65,7 +65,7 @@ class DealPipelinesTest extends EntityTestCase
     public function update()
     {
         $newLabel = 'Updated pipeline'.uniqid();
-        $response = $this->resource->update($this->entity->pipelineId, [
+        $response = $this->endpoint->update($this->entity->pipelineId, [
             'label' => $newLabel,
             'pipelineId' => $this->entity->pipelineId,
             'stages' => [
@@ -91,7 +91,7 @@ class DealPipelinesTest extends EntityTestCase
 
     protected function createEntity()
     {
-        return $this->resource->create([
+        return $this->endpoint->create([
             'label' => 'New Business Pipeline'.uniqid(),
             'displayOrder' => 5,
             'stages' => [
@@ -106,6 +106,6 @@ class DealPipelinesTest extends EntityTestCase
 
     protected function deleteEntity()
     {
-        return $this->resource->delete($this->entity->pipelineId);
+        return $this->endpoint->delete($this->entity->pipelineId);
     }
 }

--- a/tests/Integration/Endpoints/DealPropertiesTest.php
+++ b/tests/Integration/Endpoints/DealPropertiesTest.php
@@ -14,7 +14,7 @@ class DealPropertiesTest extends PropertiesTestCase
     /**
      * @var null|SevenShores\Hubspot\Endpoints\Endpoint
      */
-    protected $resourceClass = DealProperties::class;
+    protected $endpointClass = DealProperties::class;
 
     /**
      * @var string

--- a/tests/Integration/Endpoints/DealPropertyGroupsTest.php
+++ b/tests/Integration/Endpoints/DealPropertyGroupsTest.php
@@ -19,5 +19,5 @@ class DealPropertyGroupsTest extends PropertyGroupsTestCase
     /**
      * @var DealProperties
      */
-    protected $resourceClass = DealProperties::class;
+    protected $endpointClass = DealProperties::class;
 }

--- a/tests/Integration/Endpoints/DealsTest.php
+++ b/tests/Integration/Endpoints/DealsTest.php
@@ -21,22 +21,22 @@ class DealsTest extends EntityTestCase
     /**
      * @var Deals
      */
-    protected $resource;
+    protected $endpoint;
 
     /**
      * @var Deals::class
      */
-    protected $resourceClass = Deals::class;
+    protected $endpointClass = Deals::class;
 
     /**
      * @var Contacts
      */
-    protected $resourceContacts;
+    protected $endpointContacts;
 
     /**
      * @var Companies
      */
-    protected $resourceCompanies;
+    protected $endpointCompanies;
 
     /**
      * @test
@@ -53,7 +53,7 @@ class DealsTest extends EntityTestCase
      */
     public function update()
     {
-        $response = $this->resource->update($this->entity->dealId, [
+        $response = $this->endpoint->update($this->entity->dealId, [
             [
                 'name' => 'amount',
                 'value' => '70000',
@@ -71,7 +71,7 @@ class DealsTest extends EntityTestCase
     {
         $deal = $this->createEntity();
 
-        $response = $this->resource->updateBatch([
+        $response = $this->endpoint->updateBatch([
             [
                 'objectId' => $this->entity->dealId,
                 'properties' => [
@@ -89,7 +89,7 @@ class DealsTest extends EntityTestCase
 
         $this->assertEquals(202, $response->getStatusCode());
 
-        $this->resource->delete($deal->dealId);
+        $this->endpoint->delete($deal->dealId);
     }
 
     /**
@@ -97,7 +97,7 @@ class DealsTest extends EntityTestCase
      */
     public function all()
     {
-        $response = $this->resource->all([
+        $response = $this->endpoint->all([
             'offset' => 1,
             'limit' => 1,
         ]);
@@ -111,14 +111,14 @@ class DealsTest extends EntityTestCase
      */
     public function getRecentlyModified()
     {
-        $this->resource->update($this->entity->dealId, [
+        $this->endpoint->update($this->entity->dealId, [
             [
                 'name' => 'amount',
                 'value' => '70000',
             ],
         ]);
 
-        $response = $this->resource->getRecentlyModified([
+        $response = $this->endpoint->getRecentlyModified([
             'offset' => 0,
             'count' => 1,
         ]);
@@ -131,7 +131,7 @@ class DealsTest extends EntityTestCase
      */
     public function getRecentlyCreated()
     {
-        $response = $this->resource->getRecentlyCreated([
+        $response = $this->endpoint->getRecentlyCreated([
             'offset' => 0,
             'count' => 1,
         ]);
@@ -155,7 +155,7 @@ class DealsTest extends EntityTestCase
      */
     public function getById()
     {
-        $response = $this->resource->getById($this->entity->dealId);
+        $response = $this->endpoint->getById($this->entity->dealId);
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertSame('Cool Deal', $response->properties->dealname->value);
@@ -171,7 +171,7 @@ class DealsTest extends EntityTestCase
         $secondCompanyId = $this->createCompany();
         $thirdCompanyId = $this->createCompany();
 
-        $associateResponse = $this->resource->associateWithCompany($this->entity->dealId, [
+        $associateResponse = $this->endpoint->associateWithCompany($this->entity->dealId, [
             $firstCompanyId,
             $secondCompanyId,
             $thirdCompanyId,
@@ -179,7 +179,7 @@ class DealsTest extends EntityTestCase
         $this->assertEquals(204, $associateResponse->getStatusCode());
 
         // Check what was associated
-        $byIdResponse = $this->resource->getById($this->entity->dealId);
+        $byIdResponse = $this->endpoint->getById($this->entity->dealId);
 
         $associatedCompanies = $byIdResponse->associations->associatedCompanyIds;
         $expectedAssociatedCompanies = [$firstCompanyId, $secondCompanyId, $thirdCompanyId];
@@ -190,7 +190,7 @@ class DealsTest extends EntityTestCase
         $this->assertEquals($expectedAssociatedCompanies, $associatedCompanies);
 
         // Now disassociate
-        $response = $this->resource->disassociateFromCompany($this->entity->dealId, [
+        $response = $this->endpoint->disassociateFromCompany($this->entity->dealId, [
             $firstCompanyId,
             $secondCompanyId,
             $thirdCompanyId,
@@ -211,7 +211,7 @@ class DealsTest extends EntityTestCase
         $secondContactId = $this->createContact();
         $thirdContactId = $this->createContact();
 
-        $associateResponse = $this->resource->associateWithContact($this->entity->dealId, [
+        $associateResponse = $this->endpoint->associateWithContact($this->entity->dealId, [
             $firstContactId,
             $secondContactId,
             $thirdContactId,
@@ -219,7 +219,7 @@ class DealsTest extends EntityTestCase
         $this->assertSame(204, $associateResponse->getStatusCode());
 
         // Check what was associated
-        $byIdResponse = $this->resource->getById($this->entity->dealId);
+        $byIdResponse = $this->endpoint->getById($this->entity->dealId);
 
         $associatedContacts = $byIdResponse->associations->associatedVids;
         $expectedAssociatedContacts = [$firstContactId, $secondContactId, $thirdContactId];
@@ -230,7 +230,7 @@ class DealsTest extends EntityTestCase
         $this->assertEquals($expectedAssociatedContacts, $associatedContacts);
 
         // Now disassociate
-        $response = $this->resource->disassociateFromContact($this->entity->dealId, [
+        $response = $this->endpoint->disassociateFromContact($this->entity->dealId, [
             $firstContactId,
             $secondContactId,
             $thirdContactId,
@@ -251,18 +251,18 @@ class DealsTest extends EntityTestCase
 
         $deal = $this->createEntity()->dealId;
 
-        $this->resource->associateWithCompany($this->entity->dealId, [
+        $this->endpoint->associateWithCompany($this->entity->dealId, [
             $companyId,
         ]);
 
-        $this->resource->associateWithCompany($deal, [
+        $this->endpoint->associateWithCompany($deal, [
             $companyId,
         ]);
 
-        $response = $this->resource->getAssociatedDeals('company', $companyId);
+        $response = $this->endpoint->getAssociatedDeals('company', $companyId);
         $this->assertCount(2, $response->deals);
 
-        $this->resource->delete($deal);
+        $this->endpoint->delete($deal);
 
         $this->deleteCompany($companyId);
     }
@@ -276,18 +276,18 @@ class DealsTest extends EntityTestCase
 
         $deal = $this->createEntity()->dealId;
 
-        $this->resource->associateWithContact($this->entity->dealId, [
+        $this->endpoint->associateWithContact($this->entity->dealId, [
             $contactId,
         ]);
 
-        $this->resource->associateWithContact($deal, [
+        $this->endpoint->associateWithContact($deal, [
             $contactId,
         ]);
 
-        $response = $this->resource->getAssociatedDeals('contact', $contactId);
+        $response = $this->endpoint->getAssociatedDeals('contact', $contactId);
         $this->assertCount(2, $response->deals);
 
-        $this->resource->delete($deal);
+        $this->endpoint->delete($deal);
         $this->deleteContact($contactId);
     }
 
@@ -317,7 +317,7 @@ class DealsTest extends EntityTestCase
 
     protected function createEntity()
     {
-        return $this->resource->create([
+        return $this->endpoint->create([
             [
                 'value' => 'Cool Deal',
                 'name' => 'dealname',
@@ -331,24 +331,24 @@ class DealsTest extends EntityTestCase
 
     protected function deleteEntity()
     {
-        return $this->resource->delete($this->entity->dealId);
+        return $this->endpoint->delete($this->entity->dealId);
     }
 
     protected function getContacts()
     {
-        if (empty($this->resourceContacts)) {
-            $this->resourceContacts = new Contacts(new Client(['key' => getenv('HUBSPOT_TEST_API_KEY')]));
+        if (empty($this->endpointContacts)) {
+            $this->endpointContacts = new Contacts(new Client(['key' => getenv('HUBSPOT_TEST_API_KEY')]));
         }
 
-        return $this->resourceContacts;
+        return $this->endpointContacts;
     }
 
     protected function getCompanies()
     {
-        if (empty($this->resourceCompanies)) {
-            $this->resourceCompanies = new Companies(new Client(['key' => getenv('HUBSPOT_TEST_API_KEY')]));
+        if (empty($this->endpointCompanies)) {
+            $this->endpointCompanies = new Companies(new Client(['key' => getenv('HUBSPOT_TEST_API_KEY')]));
         }
 
-        return $this->resourceCompanies;
+        return $this->endpointCompanies;
     }
 }

--- a/tests/Integration/Endpoints/EcommerceBridgeTest.php
+++ b/tests/Integration/Endpoints/EcommerceBridgeTest.php
@@ -20,12 +20,12 @@ class EcommerceBridgeTest extends DefaultTestCase
     /**
      * @var EcommerceBridge
      */
-    protected $resource;
+    protected $endpoint;
 
     /**
      * @var EcommerceBridge::class
      */
-    protected $resourceClass = EcommerceBridge::class;
+    protected $endpointClass = EcommerceBridge::class;
 
     /**
      * @var int
@@ -35,7 +35,7 @@ class EcommerceBridgeTest extends DefaultTestCase
     /** @test */
     public function upsertSettings()
     {
-        $response = $this->resource->upsertSettings($this->getData());
+        $response = $this->endpoint->upsertSettings($this->getData());
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -43,7 +43,7 @@ class EcommerceBridgeTest extends DefaultTestCase
     /** @test */
     public function getSettings()
     {
-        $response = $this->resource->getSettings();
+        $response = $this->endpoint->getSettings();
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertArrayHasKey('mappings', $response->toArray());
@@ -52,7 +52,7 @@ class EcommerceBridgeTest extends DefaultTestCase
     /** @test */
     public function createOrUpdateStore()
     {
-        $response = $this->resource->createOrUpdateStore([
+        $response = $this->endpoint->createOrUpdateStore([
             'id' => static::STORE_ID,
             'label' => 'Ecommerce Bridge Test Store '.uniqid(),
             'adminUri' => 'https://ecommercebridge-test-store.myshopify.com',
@@ -64,7 +64,7 @@ class EcommerceBridgeTest extends DefaultTestCase
     /** @test */
     public function allStores()
     {
-        $response = $this->resource->allStores();
+        $response = $this->endpoint->allStores();
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertGreaterThanOrEqual(1, count($response->getData()->results));
@@ -73,7 +73,7 @@ class EcommerceBridgeTest extends DefaultTestCase
     /** @test */
     public function getStore()
     {
-        $response = $this->resource->getStore(static::STORE_ID);
+        $response = $this->endpoint->getStore(static::STORE_ID);
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertContains(static::STORE_ID, $response->toArray());
@@ -82,7 +82,7 @@ class EcommerceBridgeTest extends DefaultTestCase
     /** @test */
     public function sendSyncMessages()
     {
-        $response = $this->resource->sendSyncMessages(
+        $response = $this->endpoint->sendSyncMessages(
             static::STORE_ID,
             'CONTACT',
             [
@@ -106,7 +106,7 @@ class EcommerceBridgeTest extends DefaultTestCase
     /** @test */
     public function getAllSyncErrorsAccount()
     {
-        $response = $this->resource->getAllSyncErrorsAccount();
+        $response = $this->endpoint->getAllSyncErrorsAccount();
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertArrayHasKey('results', $response->toArray());
     }
@@ -114,7 +114,7 @@ class EcommerceBridgeTest extends DefaultTestCase
     /** @test */
     public function checkSyncStatus()
     {
-        $response = $this->resource->checkSyncStatus(
+        $response = $this->endpoint->checkSyncStatus(
             static::STORE_ID,
             'CONTACT',
             '12345'
@@ -127,7 +127,7 @@ class EcommerceBridgeTest extends DefaultTestCase
     public function importData()
     {
         $this->markTestSkipped();
-        $response = $this->resource->importData(
+        $response = $this->endpoint->importData(
             $this->getTimestamp(),
             1,
             [
@@ -159,7 +159,7 @@ class EcommerceBridgeTest extends DefaultTestCase
     public function signalImportEnd()
     {
         $this->markTestSkipped();
-        $response = $this->resource->signalImportEnd(
+        $response = $this->endpoint->signalImportEnd(
             $this->getTimestamp(),
             1,
             1,
@@ -173,7 +173,7 @@ class EcommerceBridgeTest extends DefaultTestCase
     /** @test */
     public function deleteSettings()
     {
-        $response = $this->resource->deleteSettings();
+        $response = $this->endpoint->deleteSettings();
 
         $this->assertEquals(204, $response->getStatusCode());
     }

--- a/tests/Integration/Endpoints/EmailEventsTest.php
+++ b/tests/Integration/Endpoints/EmailEventsTest.php
@@ -11,19 +11,19 @@ use SevenShores\Hubspot\Http\Client;
  */
 class EmailEventsTest extends \PHPUnit\Framework\TestCase
 {
-    protected $resource;
+    protected $endpoint;
 
     public function setUp(): void
     {
         parent::setUp();
-        $this->resource = new EmailEvents(new Client(['key' => getenv('HUBSPOT_TEST_API_KEY')]));
+        $this->endpoint = new EmailEvents(new Client(['key' => getenv('HUBSPOT_TEST_API_KEY')]));
         sleep(1);
     }
 
     /** @test */
     public function all()
     {
-        $response = $this->resource->all();
+        $response = $this->endpoint->all();
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -31,10 +31,10 @@ class EmailEventsTest extends \PHPUnit\Framework\TestCase
     /** @test */
     public function getById()
     {
-        $list = $this->resource->all(['limit' => 2]);
+        $list = $this->endpoint->all(['limit' => 2]);
 
         if (count($list->events) > 0) {
-            $response = $this->resource->getById(
+            $response = $this->endpoint->getById(
                 $list->events[0]->id,
                 $list->events[0]->created
             );
@@ -46,7 +46,7 @@ class EmailEventsTest extends \PHPUnit\Framework\TestCase
     /** @test */
     public function getCampaignIds()
     {
-        $response = $this->resource->getCampaignIds(['limit' => 2]);
+        $response = $this->endpoint->getCampaignIds(['limit' => 2]);
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -54,7 +54,7 @@ class EmailEventsTest extends \PHPUnit\Framework\TestCase
     /** @test */
     public function getCampaignIdsWithRecentActivity()
     {
-        $response = $this->resource->getCampaignIdsWithRecentActivity(['limit' => 2]);
+        $response = $this->endpoint->getCampaignIdsWithRecentActivity(['limit' => 2]);
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -62,10 +62,10 @@ class EmailEventsTest extends \PHPUnit\Framework\TestCase
     /** @test */
     public function getCampaignById()
     {
-        $list = $this->resource->getCampaignIds(['limit' => 2]);
+        $list = $this->endpoint->getCampaignIds(['limit' => 2]);
 
         if (count($list->campaigns) > 0) {
-            $response = $this->resource->getCampaignById(
+            $response = $this->endpoint->getCampaignById(
                 $list->campaigns[0]->id,
                 $list->campaigns[0]->appId
             );

--- a/tests/Integration/Endpoints/EmailSubscriptionTest.php
+++ b/tests/Integration/Endpoints/EmailSubscriptionTest.php
@@ -14,20 +14,20 @@ class EmailSubscriptionTest extends \PHPUnit\Framework\TestCase
     /**
      * @var Email
      */
-    protected $resource;
+    protected $endpoint;
 
     public function setUp(): void
     {
         parent::setUp();
 
-        $this->resource = new EmailSubscription(new Client(['key' => getenv('HUBSPOT_TEST_API_KEY')]));
+        $this->endpoint = new EmailSubscription(new Client(['key' => getenv('HUBSPOT_TEST_API_KEY')]));
         sleep(1);
     }
 
     /** @test */
     public function subscriptions()
     {
-        $response = $this->resource->subscriptions();
+        $response = $this->endpoint->subscriptions();
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -35,7 +35,7 @@ class EmailSubscriptionTest extends \PHPUnit\Framework\TestCase
     /** @test */
     public function subscriptionsTimeline()
     {
-        $response = $this->resource->subscriptionsTimeline(['limit' => 2]);
+        $response = $this->endpoint->subscriptionsTimeline(['limit' => 2]);
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -43,7 +43,7 @@ class EmailSubscriptionTest extends \PHPUnit\Framework\TestCase
     /** @test */
     public function subscriptionStatus()
     {
-        $response = $this->resource->subscriptionStatus('test@hubspot.com');
+        $response = $this->endpoint->subscriptionStatus('test@hubspot.com');
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -51,7 +51,7 @@ class EmailSubscriptionTest extends \PHPUnit\Framework\TestCase
     /** @test */
     public function updateSubscription()
     {
-        $response = $this->resource->updateSubscription('test@hubspot.com', ['unsubscribeFromAll' => true]);
+        $response = $this->endpoint->updateSubscription('test@hubspot.com', ['unsubscribeFromAll' => true]);
 
         $this->assertEquals(200, $response->getStatusCode());
     }

--- a/tests/Integration/Endpoints/EngagementsTest.php
+++ b/tests/Integration/Endpoints/EngagementsTest.php
@@ -15,17 +15,17 @@ class EngagementsTest extends EntityTestCase
     /**
      * @var Engagements
      */
-    protected $resource;
+    protected $endpoint;
 
     /**
      * @var Engagements::class
      */
-    protected $resourceClass = Engagements::class;
+    protected $endpointClass = Engagements::class;
 
     /**
      * @var Contacts
      */
-    protected $contactsResource;
+    protected $contactsEndpoint;
 
     /**
      * @var \SevenShores\Hubspot\Http\Response
@@ -34,7 +34,7 @@ class EngagementsTest extends EntityTestCase
 
     public function setUp(): void
     {
-        $this->contactsResource = new Contacts($this->getClient());
+        $this->contactsEndpoint = new Contacts($this->getClient());
 
         $this->contact = $this->createContact();
         sleep(1);
@@ -59,7 +59,7 @@ class EngagementsTest extends EntityTestCase
     /** @test */
     public function update()
     {
-        $response = $this->resource->update($this->entity->engagement->id, [
+        $response = $this->endpoint->update($this->entity->engagement->id, [
             'active' => true,
             'ownerId' => 1,
             'type' => 'NOTE',
@@ -84,7 +84,7 @@ class EngagementsTest extends EntityTestCase
     /** @test */
     public function get()
     {
-        $response = $this->resource->get($this->entity->engagement->id);
+        $response = $this->endpoint->get($this->entity->engagement->id);
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -92,7 +92,7 @@ class EngagementsTest extends EntityTestCase
     /** @test */
     public function all()
     {
-        $response = $this->resource->all();
+        $response = $this->endpoint->all();
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -100,7 +100,7 @@ class EngagementsTest extends EntityTestCase
     /** @test */
     public function recent()
     {
-        $response = $this->resource->recent();
+        $response = $this->endpoint->recent();
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -108,7 +108,7 @@ class EngagementsTest extends EntityTestCase
     /** @test */
     public function getCallDispositions()
     {
-        $response = $this->resource->getCallDispositions();
+        $response = $this->endpoint->getCallDispositions();
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertCount(6, $response->getData());
@@ -116,7 +116,7 @@ class EngagementsTest extends EntityTestCase
 
     protected function createEntity()
     {
-        return $this->resource->create([
+        return $this->endpoint->create([
             'active' => true,
             'ownerId' => 1,
             'type' => 'NOTE',
@@ -133,12 +133,12 @@ class EngagementsTest extends EntityTestCase
 
     protected function deleteEntity()
     {
-        return $this->resource->delete($this->entity->engagement->id);
+        return $this->endpoint->delete($this->entity->engagement->id);
     }
 
     protected function createContact()
     {
-        return $this->contactsResource->create([
+        return $this->contactsEndpoint->create([
             ['property' => 'email',     'value' => 'rw_test'.uniqid().'@hubspot.com'],
             ['property' => 'firstname', 'value' => 'joe'],
             ['property' => 'lastname',  'value' => 'user'],
@@ -147,6 +147,6 @@ class EngagementsTest extends EntityTestCase
 
     protected function deleteContact()
     {
-        return $this->contactsResource->delete($this->contact->vid);
+        return $this->contactsEndpoint->delete($this->contact->vid);
     }
 }

--- a/tests/Integration/Endpoints/FormsTest.php
+++ b/tests/Integration/Endpoints/FormsTest.php
@@ -14,12 +14,12 @@ class FormsTest extends EntityTestCase
     /**
      * @var null|SevenShores\Hubspot\Endpoints\Forms::class
      */
-    protected $resourceClass = Forms::class;
+    protected $endpointClass = Forms::class;
 
     /** @test */
     public function allWithNoParams()
     {
-        $response = $this->resource->all();
+        $response = $this->endpoint->all();
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertGreaterThanOrEqual(1, count($response->getData()));
@@ -34,7 +34,7 @@ class FormsTest extends EntityTestCase
     /** @test */
     public function update()
     {
-        $response = $this->resource->update($this->entity->guid, [
+        $response = $this->endpoint->update($this->entity->guid, [
             'name' => 'new name '.uniqid(),
         ]);
 
@@ -44,7 +44,7 @@ class FormsTest extends EntityTestCase
     /** @test */
     public function getById()
     {
-        $response = $this->resource->getById($this->entity->guid);
+        $response = $this->endpoint->getById($this->entity->guid);
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -62,7 +62,7 @@ class FormsTest extends EntityTestCase
     /** @test */
     public function getFields()
     {
-        $response = $this->resource->getFields($this->entity->guid);
+        $response = $this->endpoint->getFields($this->entity->guid);
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -70,7 +70,7 @@ class FormsTest extends EntityTestCase
     /** @test */
     public function getFieldByName()
     {
-        $response = $this->resource->getFieldByName($this->entity->guid, 'firstname');
+        $response = $this->endpoint->getFieldByName($this->entity->guid, 'firstname');
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -78,7 +78,7 @@ class FormsTest extends EntityTestCase
     /** @test */
     public function submit()
     {
-        $response = $this->resource->submit(getenv('HUBSPOT_TEST_PORTAL_ID'), $this->entity->guid, [
+        $response = $this->endpoint->submit(getenv('HUBSPOT_TEST_PORTAL_ID'), $this->entity->guid, [
             'fields' => [
                 [
                     'name' => 'firstname',
@@ -93,7 +93,7 @@ class FormsTest extends EntityTestCase
     // Lots of tests need an existing object to modify.
     protected function createEntity()
     {
-        return $this->resource->create([
+        return $this->endpoint->create([
             'name' => 'Test Form '.uniqid(),
             'action' => '',
             'method' => 'POST',
@@ -133,6 +133,6 @@ class FormsTest extends EntityTestCase
 
     protected function deleteEntity()
     {
-        return $this->resource->delete($this->entity->guid);
+        return $this->endpoint->delete($this->entity->guid);
     }
 }

--- a/tests/Integration/Endpoints/HubDBRowTest.php
+++ b/tests/Integration/Endpoints/HubDBRowTest.php
@@ -26,7 +26,7 @@ class HubDBRowTest extends HubDBRowTestCase
      */
     public function getRows()
     {
-        $response = $this->resource->getRows($this->entity->id, $this->portalId, true);
+        $response = $this->endpoint->getRows($this->entity->id, $this->portalId, true);
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertGreaterThanOrEqual(1, $response->totalCount);
@@ -45,7 +45,7 @@ class HubDBRowTest extends HubDBRowTestCase
      */
     public function cloneRow()
     {
-        $response = $this->resource->cloneRow($this->entity->id, $this->row->id);
+        $response = $this->endpoint->cloneRow($this->entity->id, $this->row->id);
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertContains('Test name', $response->toArray());
@@ -56,7 +56,7 @@ class HubDBRowTest extends HubDBRowTestCase
      */
     public function updateRow()
     {
-        $response = $this->resource->updateRow(
+        $response = $this->endpoint->updateRow(
             $this->entity->id,
             $this->row->id,
             [
@@ -73,7 +73,7 @@ class HubDBRowTest extends HubDBRowTestCase
      */
     public function deleteRow()
     {
-        $response = $this->resource->deleteRow(
+        $response = $this->endpoint->deleteRow(
             $this->entity->id,
             $this->row->id
         );
@@ -86,7 +86,7 @@ class HubDBRowTest extends HubDBRowTestCase
      */
     public function updateCell()
     {
-        $response = $this->resource->updateCell(
+        $response = $this->endpoint->updateCell(
             $this->entity->id,
             $this->row->id,
             $this->entity->columns[0]->id,
@@ -104,7 +104,7 @@ class HubDBRowTest extends HubDBRowTestCase
      */
     public function deleteCell()
     {
-        $response = $this->resource->deleteCell(
+        $response = $this->endpoint->deleteCell(
             $this->entity->id,
             $this->row->id,
             $this->entity->columns[0]->id
@@ -118,7 +118,7 @@ class HubDBRowTest extends HubDBRowTestCase
      */
     public function publishDraftTable()
     {
-        $response = $this->resource->publishDraftTable($this->entity->id);
+        $response = $this->endpoint->publishDraftTable($this->entity->id);
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertContains($this->entity->name, $response->toArray());
@@ -129,14 +129,14 @@ class HubDBRowTest extends HubDBRowTestCase
      */
     public function revertDraftTable()
     {
-        $response = $this->resource->revertDraftTable($this->entity->id);
+        $response = $this->endpoint->revertDraftTable($this->entity->id);
 
         $this->assertEquals(200, $response->getStatusCode());
     }
 
     protected function createRow()
     {
-        return $this->resource->addRow($this->entity->id, [
+        return $this->endpoint->addRow($this->entity->id, [
             $this->entity->columns[0]->id => 'Test name',
             $this->entity->columns[1]->id => 10,
         ]);

--- a/tests/Integration/Endpoints/HubDBTest.php
+++ b/tests/Integration/Endpoints/HubDBTest.php
@@ -15,7 +15,7 @@ class HubDBTest extends HubDBRowTestCase
      */
     public function tables()
     {
-        $response = $this->resource->tables();
+        $response = $this->endpoint->tables();
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertGreaterThanOrEqual(1, count($response->objects));
@@ -26,7 +26,7 @@ class HubDBTest extends HubDBRowTestCase
      */
     public function getTable()
     {
-        $response = $this->resource->getTable($this->entity->id, $this->portalId);
+        $response = $this->endpoint->getTable($this->entity->id, $this->portalId);
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertContains($this->entity->id, $response->toArray());
@@ -45,12 +45,12 @@ class HubDBTest extends HubDBRowTestCase
      */
     public function cloneTable()
     {
-        $response = $this->resource->cloneTable($this->entity->id, 'Cloned Table');
+        $response = $this->endpoint->cloneTable($this->entity->id, 'Cloned Table');
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertContains('Cloned Table', $response->toArray());
 
-        $this->resource->deleteTable($response->id);
+        $this->endpoint->deleteTable($response->id);
     }
 
     /**
@@ -58,7 +58,7 @@ class HubDBTest extends HubDBRowTestCase
      */
     public function updateTable()
     {
-        $response = $this->resource->updateTable($this->entity->id, 'Updated Table');
+        $response = $this->endpoint->updateTable($this->entity->id, 'Updated Table');
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertContains('Updated Table', $response->toArray());
@@ -81,7 +81,7 @@ class HubDBTest extends HubDBRowTestCase
      */
     public function import()
     {
-        $response = $this->resource->import(
+        $response = $this->endpoint->import(
             $this->entity->id,
             __DIR__.'/../../data/hubdb.csv',
             [

--- a/tests/Integration/Endpoints/LineItemsTest.php
+++ b/tests/Integration/Endpoints/LineItemsTest.php
@@ -18,17 +18,17 @@ class LineItemsTest extends EntityTestCase
     /**
      * @var LineItems
      */
-    protected $resource;
+    protected $endpoint;
 
     /**
      * @var LineItems::class
      */
-    protected $resourceClass = LineItems::class;
+    protected $endpointClass = LineItems::class;
 
     /**
      * $var Products.
      */
-    protected $resourceProducts;
+    protected $endpointProducts;
 
     /**
      * $var \SevenShores\Hubspot\Http\Response.
@@ -54,7 +54,7 @@ class LineItemsTest extends EntityTestCase
     /** @test */
     public function all()
     {
-        $response = $this->resource->all();
+        $response = $this->endpoint->all();
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertGreaterThanOrEqual(1, count($response->objects));
@@ -63,7 +63,7 @@ class LineItemsTest extends EntityTestCase
     /** @test */
     public function getById()
     {
-        $response = $this->resource->getById($this->entity->objectId);
+        $response = $this->endpoint->getById($this->entity->objectId);
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -78,12 +78,12 @@ class LineItemsTest extends EntityTestCase
             $lineItem->objectId,
         ];
 
-        $response = $this->resource->getBatchByIds($ids);
+        $response = $this->endpoint->getBatchByIds($ids);
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertCount(2, $response->toArray());
 
-        $this->resource->delete($lineItem->objectId);
+        $this->endpoint->delete($lineItem->objectId);
     }
 
     /** @test */
@@ -95,7 +95,7 @@ class LineItemsTest extends EntityTestCase
     /** @test */
     public function createBatch()
     {
-        $response = $this->resource->createBatch([
+        $response = $this->endpoint->createBatch([
             $this->getData(),
             $this->getData(),
         ]);
@@ -104,7 +104,7 @@ class LineItemsTest extends EntityTestCase
 
         sleep(1);
 
-        $this->resource->deleteBatch(array_map(function ($lineItem) {
+        $this->endpoint->deleteBatch(array_map(function ($lineItem) {
             return $lineItem->objectId;
         }, array_values($response->getData())));
     }
@@ -112,7 +112,7 @@ class LineItemsTest extends EntityTestCase
     /** @test */
     public function update()
     {
-        $response = $this->resource->update($this->entity->objectId, [
+        $response = $this->endpoint->update($this->entity->objectId, [
             ['name' => 'name', 'value' => 'An updated custom name for the product for this line item. Discounting 5% on bulk purchase.'],
         ]);
 
@@ -124,7 +124,7 @@ class LineItemsTest extends EntityTestCase
     {
         $lineItem = $this->createEntity();
 
-        $response = $this->resource->updateBatch([
+        $response = $this->endpoint->updateBatch([
             [
                 'objectId' => $this->entity->objectId,
                 'properties' => [
@@ -155,7 +155,7 @@ class LineItemsTest extends EntityTestCase
 
         $this->assertEquals(200, $response->getStatusCode());
 
-        $this->resource->delete($lineItem->objectId);
+        $this->endpoint->delete($lineItem->objectId);
     }
 
     /** @test */
@@ -171,14 +171,14 @@ class LineItemsTest extends EntityTestCase
     /** @test */
     public function deleteBatch()
     {
-        $response = $this->resource->createBatch([
+        $response = $this->endpoint->createBatch([
             $this->getData(),
             $this->getData(),
         ]);
 
         sleep(1);
 
-        $deleteResponse = $this->resource->deleteBatch(array_map(function ($lineItem) {
+        $deleteResponse = $this->endpoint->deleteBatch(array_map(function ($lineItem) {
             return $lineItem->objectId;
         }, array_values($response->getData())));
 
@@ -188,19 +188,19 @@ class LineItemsTest extends EntityTestCase
     /** @test */
     public function getLineItemChanges()
     {
-        $response = $this->resource->getLineItemChanges();
+        $response = $this->endpoint->getLineItemChanges();
 
         $this->assertEquals(200, $response->getStatusCode());
     }
 
     protected function createEntity()
     {
-        return $this->resource->create($this->getData());
+        return $this->endpoint->create($this->getData());
     }
 
     protected function deleteEntity()
     {
-        return $this->resource->delete($this->entity->objectId);
+        return $this->endpoint->delete($this->entity->objectId);
     }
 
     protected function getData(): array
@@ -215,11 +215,11 @@ class LineItemsTest extends EntityTestCase
 
     protected function getProducts()
     {
-        if (empty($this->resourceProducts)) {
-            $this->resourceProducts = new Products(new Client(['key' => getenv('HUBSPOT_TEST_API_KEY')]));
+        if (empty($this->endpointProducts)) {
+            $this->endpointProducts = new Products(new Client(['key' => getenv('HUBSPOT_TEST_API_KEY')]));
         }
 
-        return $this->resourceProducts;
+        return $this->endpointProducts;
     }
 
     protected function createProduct()

--- a/tests/Integration/Endpoints/ObjectPropertiesTest.php
+++ b/tests/Integration/Endpoints/ObjectPropertiesTest.php
@@ -18,7 +18,7 @@ class ObjectPropertiesTest extends PropertiesTestCase
 
     public function setUp(): void
     {
-        $this->resource = Factory::create(getenv('HUBSPOT_TEST_API_KEY'))->objectProperties('products');
+        $this->endpoint = Factory::create(getenv('HUBSPOT_TEST_API_KEY'))->objectProperties('products');
         sleep(1);
         $this->entity = $this->createEntity();
     }

--- a/tests/Integration/Endpoints/ObjectPropertyGroupsTest.php
+++ b/tests/Integration/Endpoints/ObjectPropertyGroupsTest.php
@@ -18,7 +18,7 @@ class ObjectPropertyGroupsTest extends PropertyGroupsTestCase
 
     public function setUp(): void
     {
-        $this->resource = Factory::create(getenv('HUBSPOT_TEST_API_KEY'))->objectProperties('products');
+        $this->endpoint = Factory::create(getenv('HUBSPOT_TEST_API_KEY'))->objectProperties('products');
         sleep(1);
         $this->entity = $this->createEntity();
     }

--- a/tests/Integration/Endpoints/PagesTest.php
+++ b/tests/Integration/Endpoints/PagesTest.php
@@ -13,7 +13,7 @@ class PagesTest extends EntityTestCase
     /**
      * @var null|SevenShores\Hubspot\Endpoints\Endpoint::class
      */
-    protected $resourceClass = 'SevenShores\Hubspot\Endpoints\Pages';
+    protected $endpointClass = 'SevenShores\Hubspot\Endpoints\Pages';
 
     /** @test */
     public function create()
@@ -24,7 +24,7 @@ class PagesTest extends EntityTestCase
     /** @test */
     public function update()
     {
-        $response = $this->resource->update(
+        $response = $this->endpoint->update(
             $this->entity->id,
             ['name' => 'Updated '.$this->entity->name]
         );
@@ -35,7 +35,7 @@ class PagesTest extends EntityTestCase
     /** @test */
     public function getById()
     {
-        $response = $this->resource->getById($this->entity->id);
+        $response = $this->endpoint->getById($this->entity->id);
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -53,7 +53,7 @@ class PagesTest extends EntityTestCase
     /** @test */
     public function all()
     {
-        $response = $this->resource->all();
+        $response = $this->endpoint->all();
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -61,22 +61,22 @@ class PagesTest extends EntityTestCase
     /** @test */
     public function clonePage()
     {
-        $response = $this->resource->clonePage($this->entity->id, 'New page name');
+        $response = $this->endpoint->clonePage($this->entity->id, 'New page name');
 
         $this->assertEquals(201, $response->getStatusCode());
 
-        $this->resource->delete($response->id);
+        $this->endpoint->delete($response->id);
     }
 
     protected function createEntity()
     {
-        return $this->resource->create([
+        return $this->endpoint->create([
             'name' => 'My Super Awesome Post(AutoTest)',
         ]);
     }
 
     protected function deleteEntity()
     {
-        return $this->resource->delete($this->entity->id);
+        return $this->endpoint->delete($this->entity->id);
     }
 }

--- a/tests/Integration/Endpoints/ProductsTest.php
+++ b/tests/Integration/Endpoints/ProductsTest.php
@@ -16,17 +16,17 @@ class ProductsTest extends EntityTestCase
     /**
      * @var SevenShores\Hubspot\Endpoints\Products
      */
-    protected $resource;
+    protected $endpoint;
 
     /**
      * @var SevenShores\Hubspot\Endpoints\Products::class
      */
-    protected $resourceClass = Products::class;
+    protected $endpointClass = Products::class;
 
     /** @test */
     public function all()
     {
-        $response = $this->resource->all();
+        $response = $this->endpoint->all();
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertGreaterThanOrEqual(1, count($response->objects));
@@ -35,7 +35,7 @@ class ProductsTest extends EntityTestCase
     /** @test */
     public function getById()
     {
-        $response = $this->resource->getById($this->entity->objectId);
+        $response = $this->endpoint->getById($this->entity->objectId);
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -50,12 +50,12 @@ class ProductsTest extends EntityTestCase
             $product->objectId,
         ];
 
-        $response = $this->resource->getBatchByIds($ids);
+        $response = $this->endpoint->getBatchByIds($ids);
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertCount(2, $response->toArray());
 
-        $this->resource->delete($product->objectId);
+        $this->endpoint->delete($product->objectId);
     }
 
     /** @test */
@@ -67,7 +67,7 @@ class ProductsTest extends EntityTestCase
     /** @test */
     public function createBatch()
     {
-        $response = $this->resource->createBatch([
+        $response = $this->endpoint->createBatch([
             $this->getData(),
             $this->getData(),
         ]);
@@ -76,7 +76,7 @@ class ProductsTest extends EntityTestCase
 
         sleep(1);
 
-        $this->resource->deleteBatch(array_map(function ($product) {
+        $this->endpoint->deleteBatch(array_map(function ($product) {
             return $product->objectId;
         }, array_values($response->getData())));
     }
@@ -84,7 +84,7 @@ class ProductsTest extends EntityTestCase
     /** @test */
     public function update()
     {
-        $response = $this->resource->update($this->entity->objectId, [
+        $response = $this->endpoint->update($this->entity->objectId, [
             ['name' => 'name', 'value' => 'An updated product'],
         ]);
 
@@ -96,7 +96,7 @@ class ProductsTest extends EntityTestCase
     {
         $product = $this->createEntity();
 
-        $response = $this->resource->updateBatch([
+        $response = $this->endpoint->updateBatch([
             [
                 'objectId' => $this->entity->objectId,
                 'properties' => [
@@ -127,7 +127,7 @@ class ProductsTest extends EntityTestCase
 
         $this->assertEquals(200, $response->getStatusCode());
 
-        $this->resource->delete($product->objectId);
+        $this->endpoint->delete($product->objectId);
     }
 
     /** @test */
@@ -143,14 +143,14 @@ class ProductsTest extends EntityTestCase
     /** @test */
     public function deleteBatch()
     {
-        $response = $this->resource->createBatch([
+        $response = $this->endpoint->createBatch([
             $this->getData(),
             $this->getData(),
         ]);
 
         sleep(1);
 
-        $deleteResponse = $this->resource->deleteBatch(array_map(function ($product) {
+        $deleteResponse = $this->endpoint->deleteBatch(array_map(function ($product) {
             return $product->objectId;
         }, array_values($response->getData())));
 
@@ -160,18 +160,18 @@ class ProductsTest extends EntityTestCase
     /** @test */
     public function getProductChanges()
     {
-        $response = $this->resource->getProductChanges();
+        $response = $this->endpoint->getProductChanges();
 
         $this->assertEquals(200, $response->getStatusCode());
     }
 
     protected function createEntity()
     {
-        return $this->resource->create($this->getData());
+        return $this->endpoint->create($this->getData());
     }
 
     protected function deleteEntity()
     {
-        return $this->resource->delete($this->entity->objectId);
+        return $this->endpoint->delete($this->entity->objectId);
     }
 }

--- a/tests/Integration/Endpoints/TimelineEventTypePropertyTest.php
+++ b/tests/Integration/Endpoints/TimelineEventTypePropertyTest.php
@@ -15,7 +15,7 @@ class TimelineEventTypePropertyTest extends TimelineWithProprtyTestCase
      */
     public function getEventTypeProperties()
     {
-        $response = $this->resource->getEventTypeProperties($this->appId, $this->entity->id);
+        $response = $this->endpoint->getEventTypeProperties($this->appId, $this->entity->id);
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertGreaterThanOrEqual(1, count($response->toArray()));
@@ -35,7 +35,7 @@ class TimelineEventTypePropertyTest extends TimelineWithProprtyTestCase
      */
     public function updateEventTypeProperty()
     {
-        $response = $this->resource->updateEventTypeProperty(
+        $response = $this->endpoint->updateEventTypeProperty(
             $this->appId,
             $this->entity->id,
             $this->property->id,

--- a/tests/Integration/Endpoints/TimelineEventTypeTest.php
+++ b/tests/Integration/Endpoints/TimelineEventTypeTest.php
@@ -15,7 +15,7 @@ class TimelineEventTypeTest extends TimelineTestCase
      */
     public function getEventTypes()
     {
-        $response = $this->resource->getEventTypes($this->appId);
+        $response = $this->endpoint->getEventTypes($this->appId);
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertGreaterThanOrEqual(1, count($response->toArray()));
@@ -26,7 +26,7 @@ class TimelineEventTypeTest extends TimelineTestCase
      */
     public function getEventTypeById()
     {
-        $response = $this->resource->getEventTypeById($this->appId, $this->entity->id);
+        $response = $this->endpoint->getEventTypeById($this->appId, $this->entity->id);
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertContains($this->entity->id, $response->toArray());
@@ -46,7 +46,7 @@ class TimelineEventTypeTest extends TimelineTestCase
      */
     public function updateEventType()
     {
-        $response = $this->resource->updateEventType(
+        $response = $this->endpoint->updateEventType(
             $this->appId,
             $this->entity->id,
             'Updated Test Event Name',


### PR DESCRIPTION
### Updated naming from resources to endpoints

With the [v5.0.0](https://github.com/HubSpot/hubspot-php/releases/tag/v5.0.0) release, **Resources** concept disappears to adopt **Endpoints**. 

This pull request tries to update these concept in the names of the properties, **mainly in the tests**, but also in some areas of the project where it had not yet been updated.

### Changes:
- Updated property names that still reference `resources` and not `endpoints`
- Updated README comment talking about **resources** to **endpoints**.