### PR TITLE
README: Fix Config Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ $hubspot = SevenShores\Hubspot\Factory::createWithOAuth2Token('access-token');
 
 $hubspot = new SevenShores\Hubspot\Factory([
   'key'      => 'demo',
-  'oauth2'   => 'false', // default
+  'oauth2'   => false, // default
 ]);
 
 // Then you can call a resource 


### PR DESCRIPTION
The `oauth2` config is [treated as a boolean](https://github.com/HubSpot/hubspot-php/blob/master/src/Http/Client.php#L68). If someone copies and pastes this example they will get unexpected behavior because `'false'` evaluates to `true` if converted to a boolean.

```
php > $oauth = 'false';
php > var_dump(isset($oauth) ? $oauth : false);
string(5) "false"
php > var_dump((bool)$oauth);
bool(true)
```