### PR TITLE
Fix exceptions from `RetryMiddlewareFactory` callback method signature mismatch

### DIFF
--- a/src/RetryMiddlewareFactory.php
+++ b/src/RetryMiddlewareFactory.php
@@ -2,7 +2,6 @@
 
 namespace SevenShores\Hubspot;
 
-use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
@@ -64,8 +63,7 @@ class RetryMiddlewareFactory
         return function (
             $retries,
             Request $request,
-            Response $response = null,
-            RequestException $exception = null
+            Response $response = null
         ) use ($from, $to, $maxRetries) {
             if ($retries >= $maxRetries) {
                 return false;
@@ -86,8 +84,7 @@ class RetryMiddlewareFactory
         return function (
             $retries,
             Request $request,
-            Response $response = null,
-            RequestException $exception = null
+            Response $response = null
         ) use ($codes, $maxRetries) {
             if ($retries >= $maxRetries) {
                 return false;


### PR DESCRIPTION
```
SevenShores\Hubspot\RetryMiddlewareFactory::SevenShores\Hubspot\{closure}():
Argument #4 ($exception) must be of type ?GuzzleHttp\Exception\RequestException, TypeError given,
called in /var/task/vendor/guzzlehttp/guzzle/src/RetryMiddleware.php on line 99
```

I periodically see this error, assumingly from `json_decode()` failing on the response body from a server error message like a gateway timeout or network connection lost.

This package's Closure functions passed into `GuzzleHttp\Middleware::retry()` define its 4th argument as `RequestException $exception = null` when the callback can receive other exceptions, which will cause another cascading exception from a method signature mismatch. Class `GuzzleHttp\RetryMiddleware` doesn't apply such typehinting to its `$reason` variable: https://github.com/guzzle/guzzle/blob/be2902f14e4d04461d5d95b5f08261c715cbc74f/src/RetryMiddleware.php#L97-L102

~~Instead apply parent interface `Throwable` since `TypeError` doesn't implement `Exception`.~~

The alternative is just removing this `$exception` argument since it's unused in both closures. The callee ignores extra parameters when a PHP function doesn't define additional arguments.