### PR TITLE
Add PHP 8.1 return types to the Response class

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -3,6 +3,7 @@
 namespace SevenShores\Hubspot\Http;
 
 use ArrayAccess;
+use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 
@@ -106,7 +107,7 @@ class Response implements ResponseInterface, ArrayAccess
      *
      * @return string HTTP protocol version
      */
-    public function getProtocolVersion()
+    public function getProtocolVersion(): string
     {
         return $this->response->getProtocolVersion();
     }
@@ -125,7 +126,7 @@ class Response implements ResponseInterface, ArrayAccess
      *
      * @return self
      */
-    public function withProtocolVersion($version)
+    public function withProtocolVersion($version): MessageInterface
     {
         return $this->response->withProtocolVersion($version);
     }
@@ -155,7 +156,7 @@ class Response implements ResponseInterface, ArrayAccess
      *               key MUST be a header name, and each value MUST be an array of strings
      *               for that header.
      */
-    public function getHeaders()
+    public function getHeaders(): array
     {
         return $this->response->getHeaders();
     }
@@ -169,7 +170,7 @@ class Response implements ResponseInterface, ArrayAccess
      *              name using a case-insensitive string comparison. Returns false if
      *              no matching header name is found in the message.
      */
-    public function hasHeader($name)
+    public function hasHeader($name): bool
     {
         return $this->response->hasHeader($name);
     }
@@ -189,7 +190,7 @@ class Response implements ResponseInterface, ArrayAccess
      *                  header. If the header does not appear in the message, this method MUST
      *                  return an empty array.
      */
-    public function getHeader($name)
+    public function getHeader($name): array
     {
         return $this->response->getHeader($name);
     }
@@ -214,7 +215,7 @@ class Response implements ResponseInterface, ArrayAccess
      *                concatenated together using a comma. If the header does not appear in
      *                the message, this method MUST return an empty string.
      */
-    public function getHeaderLine($name)
+    public function getHeaderLine($name): string
     {
         return $this->response->getHeaderLine($name);
     }
@@ -236,7 +237,7 @@ class Response implements ResponseInterface, ArrayAccess
      *
      * @return self
      */
-    public function withHeader($name, $value)
+    public function withHeader($name, $value): MessageInterface
     {
         return $this->response->withHeader($name, $value);
     }
@@ -259,7 +260,7 @@ class Response implements ResponseInterface, ArrayAccess
      *
      * @return self
      */
-    public function withAddedHeader($name, $value)
+    public function withAddedHeader($name, $value): MessageInterface
     {
         return $this->response->withAddedHeader($name, $value);
     }
@@ -277,7 +278,7 @@ class Response implements ResponseInterface, ArrayAccess
      *
      * @return self
      */
-    public function withoutHeader($name)
+    public function withoutHeader($name): MessageInterface
     {
         return $this->response->withoutHeader($name);
     }
@@ -287,7 +288,7 @@ class Response implements ResponseInterface, ArrayAccess
      *
      * @return StreamInterface returns the body as a stream
      */
-    public function getBody()
+    public function getBody(): StreamInterface
     {
         return $this->response->getBody();
     }
@@ -307,7 +308,7 @@ class Response implements ResponseInterface, ArrayAccess
      *
      * @return self
      */
-    public function withBody(StreamInterface $body)
+    public function withBody(StreamInterface $body): MessageInterface
     {
         return $this->response->withBody($body);
     }
@@ -320,7 +321,7 @@ class Response implements ResponseInterface, ArrayAccess
      *
      * @return int status code
      */
-    public function getStatusCode()
+    public function getStatusCode(): int
     {
         return $this->response->getStatusCode();
     }
@@ -348,7 +349,7 @@ class Response implements ResponseInterface, ArrayAccess
      *
      * @return self
      */
-    public function withStatus($code, $reasonPhrase = '')
+    public function withStatus($code, $reasonPhrase = ''): ResponseInterface
     {
         return $this->response->withStatus($code, $reasonPhrase);
     }
@@ -367,7 +368,7 @@ class Response implements ResponseInterface, ArrayAccess
      *
      * @return string reason phrase; must return an empty string if none present
      */
-    public function getReasonPhrase()
+    public function getReasonPhrase(): string
     {
         return $this->response->getReasonPhrase();
     }


### PR DESCRIPTION
Following on from https://github.com/HubSpot/hubspot-php/issues/383 there are a few more missing return types in the `SevenShores\Hubspot\Http\Response` class.