### PR TITLE
Support psr/http-message:^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": ">=7.3",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^7.3",
-        "psr/http-message": "^1.1"
+        "psr/http-message": "^1.1 || ^2.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.4",


### PR DESCRIPTION
See https://www.php-fig.org/psr/psr-7/meta/#72-type-additions

It looks like this package is already compatible with the new type annotations: https://github.com/HubSpot/hubspot-php/commit/ef7e73e5e872edde487d7587b2cd9ecc2297832b

However, composer.json only declares compatibility with version 1.1.