### PR TITLE
Create Timestamp.php

### DIFF
--- a/src/Utils/Timestamp.php
+++ b/src/Utils/Timestamp.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace SevenShores\Hubspot\Utils;
+
+class Timestamp
+{
+    public static function getCurrentTimestampWithMilliseconds(): int
+    {
+        return intval(microtime(true) * 1000);
+    }
+}


### PR DESCRIPTION
`Signature::isValid()` references a 'Timestamp' class that does not exist in this project. 