### PR TITLE
Add EmailSubscription methods for communication-preferences v3

### DIFF
--- a/src/Endpoints/EmailSubscription.php
+++ b/src/Endpoints/EmailSubscription.php
@@ -3,10 +3,73 @@
 namespace SevenShores\Hubspot\Endpoints;
 
 /**
- * @see https://developers.hubspot.com/docs/methods/email/email_subscriptions_overview
+ * @see https://developers.hubspot.com/docs/api-reference/legacy/communication-preferences/v3/guide
  */
 class EmailSubscription extends Endpoint
 {
+    /**
+     * Get all subscription definitions for the portal.
+     *
+     * @see https://developers.hubspot.com/docs/api-reference/legacy/communication-preferences/v3/get-subscription-definitions
+     *
+     * @return \SevenShores\Hubspot\Http\Response
+     */
+    public function subscriptionDefinitions()
+    {
+        $endpoint = 'https://api.hubapi.com/communication-preferences/v3/definitions';
+
+        return $this->client->request('get', $endpoint);
+    }
+
+    /**
+     * Get subscription statuses for a contact email address.
+     *
+     * @see https://developers.hubspot.com/docs/api-reference/legacy/communication-preferences/v3/get-subscription-statuses-for-a-contact
+     *
+     * @param string $emailAddress
+     *
+     * @return \SevenShores\Hubspot\Http\Response
+     */
+    public function subscriptionStatuses($emailAddress)
+    {
+        $emailAddress = url_encode($emailAddress);
+        $endpoint = "https://api.hubapi.com/communication-preferences/v3/status/email/{$emailAddress}";
+
+        return $this->client->request('get', $endpoint);
+    }
+
+    /**
+     * Subscribe a contact to a given subscription type.
+     *
+     * @see https://developers.hubspot.com/docs/api-reference/legacy/communication-preferences/v3/subscribe-contact
+     *
+     * @param array $data
+     *
+     * @return \SevenShores\Hubspot\Http\Response
+     */
+    public function subscribe(array $data = [])
+    {
+        $endpoint = 'https://api.hubapi.com/communication-preferences/v3/subscribe';
+
+        return $this->client->request('post', $endpoint, ['json' => $data]);
+    }
+
+    /**
+     * Unsubscribe a contact from a given subscription type.
+     *
+     * @see https://developers.hubspot.com/docs/api-reference/legacy/communication-preferences/v3/unsubscribe-contact
+     *
+     * @param array $data
+     *
+     * @return \SevenShores\Hubspot\Http\Response
+     */
+    public function unsubscribe(array $data = [])
+    {
+        $endpoint = 'https://api.hubapi.com/communication-preferences/v3/unsubscribe';
+
+        return $this->client->request('post', $endpoint, ['json' => $data]);
+    }
+
     /**
      * Get email subscription types for a portal.
      *

--- a/tests/unit/Endpoints/EmailSubscriptionTest.php
+++ b/tests/unit/Endpoints/EmailSubscriptionTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace SevenShores\Hubspot\Tests\Unit\Endpoints;
+
+use PHPUnit\Framework\TestCase;
+use SevenShores\Hubspot\Endpoints\EmailSubscription;
+use SevenShores\Hubspot\Http\Client;
+
+class EmailSubscriptionTest extends TestCase
+{
+    public function test_subscription_definitions_uses_v3_definitions_endpoint()
+    {
+        $client = new RecordingClient();
+        $endpoint = new EmailSubscription($client);
+
+        $result = $endpoint->subscriptionDefinitions();
+
+        $this->assertSame('ok', $result);
+        $this->assertSame([
+            [
+                'method' => 'get',
+                'endpoint' => 'https://api.hubapi.com/communication-preferences/v3/definitions',
+                'options' => [],
+                'queryString' => null,
+                'requiresAuth' => true,
+            ],
+        ], $client->calls);
+    }
+
+    public function test_subscription_statuses_uses_v3_status_endpoint()
+    {
+        $client = new RecordingClient();
+        $endpoint = new EmailSubscription($client);
+
+        $result = $endpoint->subscriptionStatuses('test+tag@example.com');
+
+        $this->assertSame('ok', $result);
+        $this->assertSame([
+            [
+                'method' => 'get',
+                'endpoint' => 'https://api.hubapi.com/communication-preferences/v3/status/email/test%2Btag%40example.com',
+                'options' => [],
+                'queryString' => null,
+                'requiresAuth' => true,
+            ],
+        ], $client->calls);
+    }
+
+    public function test_subscribe_posts_to_v3_subscribe_endpoint()
+    {
+        $client = new RecordingClient();
+        $endpoint = new EmailSubscription($client);
+        $data = [
+            'emailAddress' => 'test@example.com',
+            'subscriptionId' => '123',
+            'legalBasis' => 'CONSENT_WITH_NOTICE',
+        ];
+
+        $result = $endpoint->subscribe($data);
+
+        $this->assertSame('ok', $result);
+        $this->assertSame([
+            [
+                'method' => 'post',
+                'endpoint' => 'https://api.hubapi.com/communication-preferences/v3/subscribe',
+                'options' => ['json' => $data],
+                'queryString' => null,
+                'requiresAuth' => true,
+            ],
+        ], $client->calls);
+    }
+
+    public function test_unsubscribe_posts_to_v3_unsubscribe_endpoint()
+    {
+        $client = new RecordingClient();
+        $endpoint = new EmailSubscription($client);
+        $data = [
+            'emailAddress' => 'test@example.com',
+            'subscriptionId' => '123',
+            'legalBasis' => 'CONSENT_WITH_NOTICE',
+        ];
+
+        $result = $endpoint->unsubscribe($data);
+
+        $this->assertSame('ok', $result);
+        $this->assertSame([
+            [
+                'method' => 'post',
+                'endpoint' => 'https://api.hubapi.com/communication-preferences/v3/unsubscribe',
+                'options' => ['json' => $data],
+                'queryString' => null,
+                'requiresAuth' => true,
+            ],
+        ], $client->calls);
+    }
+}
+
+class RecordingClient extends Client
+{
+    public $calls = [];
+
+    public function request(string $method, string $endpoint, array $options = [], $query_string = null, bool $requires_auth = true)
+    {
+        $this->calls[] = [
+            'method' => $method,
+            'endpoint' => $endpoint,
+            'options' => $options,
+            'queryString' => $query_string,
+            'requiresAuth' => $requires_auth,
+        ];
+
+        return 'ok';
+    }
+}


### PR DESCRIPTION
## Summary

Implement the missing Communication Preferences Subscriptions v3 endpoints in `EmailSubscription`:

- `GET /communication-preferences/v3/definitions`
- `GET /communication-preferences/v3/status/email/{emailAddress}`
- `POST /communication-preferences/v3/subscribe`
- `POST /communication-preferences/v3/unsubscribe`

Keep existing legacy methods in place for backward compatibility.

## Tests

Add focused unit tests in `tests/unit/Endpoints/EmailSubscriptionTest.php` to verify request method, endpoint path, payload, and URL encoding for `emailAddress` in subscription status calls.

Closes #435